### PR TITLE
Adding apt-get update to avoid pulling old dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
         - image: circleci/node:8-stretch
     steps:
       - checkout
-      - run: sudo apt-get install -y python3-pip
+      - run: sudo apt-get update && sudo apt-get install -y python3-pip
       - run:
           name: Install publish dependencies
           command: sudo pip3 install -U awscli
@@ -19,7 +19,7 @@ jobs:
         - image: circleci/node:10-stretch
     steps:
       - checkout
-      - run: sudo apt-get install -y python3-pip
+      - run: sudo apt-get update && sudo apt-get install -y python3-pip
       - run:
           name: Install publish dependencies
           command: sudo pip3 install -U awscli
@@ -33,7 +33,7 @@ jobs:
         - image: circleci/node:12-stretch
     steps:
       - checkout
-      - run: sudo apt-get install -y python3-pip
+      - run: sudo apt-get update && sudo apt-get install -y python3-pip
       - run:
           name: Install publish dependencies
           command: sudo pip3 install -U awscli


### PR DESCRIPTION
CircleCI has suggested this as the solution for a similar issue to the one we've seen with publishing the Node 8 layer.  See https://discuss.circleci.com/t/all-builds-now-throwing-an-error-because-of-a-missing-debian-dependency/32345/9

Signed-off-by: mrickard <mrickard@newrelic.com>