### PR TITLE
fix: Remove deprecated runtimes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,5 @@
 version: 2
 jobs:
-  publish-nodejs10x:
-    docker:
-        - image: circleci/node:10-stretch
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y python3-pip
-      - run:
-          name: Install publish dependencies
-          command: sudo pip3 install -U awscli
-      - run:
-          name: Publish layer
-          command: |
-            cd nodejs
-            ./publish-layers.sh nodejs10.x
   publish-nodejs12x:
     docker:
         - image: circleci/node:12-stretch
@@ -42,19 +28,6 @@ jobs:
           command: |
             cd nodejs
             ./publish-layers.sh nodejs14.x
-  publish-python27:
-    docker:
-      - image: circleci/python:2.7
-    steps:
-      - checkout
-      - run:
-          name: Install publish dependencies
-          command: sudo pip install -U awscli
-      - run:
-          name: Publish layer
-          command: |
-            cd python
-            ./publish-layers.sh python2.7
   publish-python36:
     docker:
       - image: circleci/python:3.6
@@ -154,12 +127,6 @@ workflows:
   version: 2
   publish-layers:
     jobs:
-      - publish-nodejs10x:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*_nodejs/
       - publish-nodejs12x:
           filters:
             branches:
@@ -172,12 +139,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*_nodejs/
-      - publish-python27:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*_python/
       - publish-python36:
           filters:
             branches:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ cd java;
 cd ..
 ```
 
+```
+cd extension;
+./publish-layer.sh
+cd ..
+```
+
 ## Attaching Custom Lambda Layer ARNs
 
 The layers published to your account may be used directly within SAM, Cloudformation Templates, Serverless.yml, or other configuration methods that allow specifying the use of layers by ARN.

--- a/java/publish-layers.sh
+++ b/java/publish-layers.sh
@@ -33,7 +33,7 @@ REGIONS=(
 )
 
 function usage {
-    echo "./publish-layers.sh [java8, java11]"
+    echo "./publish-layers.sh [java8.al2, java11]"
 }
 
 function download-extension {


### PR DESCRIPTION
Node 10 was officially out of stage 2 support on September 17. Python 2.7 is out of stage 2 support September 30.