### PR TITLE
Support any Java handler

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-joda:2.12.2")
     testImplementation("junit:junit:4.13")
+    testImplementation('com.github.stefanbirkner:system-lambda:1.2.0')
+    testImplementation('org.mockito:mockito-core:3.12.4')
 }
 
 task packageFat(type: Zip) {

--- a/java/src/main/java/com/newrelic/java/HandlerWrapper.java
+++ b/java/src/main/java/com/newrelic/java/HandlerWrapper.java
@@ -21,15 +21,16 @@ public class HandlerWrapper {
     private static RequestStreamHandler requestStreamHandler;
 
     static {
-        setupHandlers();
-    }
-
-    static void setupHandlers() {
         // Obtain an instance of the OpenTracing Tracer of your choice
         Tracer tracer = LambdaTracer.INSTANCE;
         // Register your tracer as the Global Tracer
         GlobalTracer.registerIfAbsent(tracer);
 
+        // Set up handlers
+        setupHandlers();
+    }
+
+    static void setupHandlers() {
         String handler = System.getenv(HANDLER_ENV_VAR);
         String[] parts = handler.split("::");
         String handlerClass = parts[0];

--- a/java/src/main/java/com/newrelic/java/HandlerWrapper.java
+++ b/java/src/main/java/com/newrelic/java/HandlerWrapper.java
@@ -59,7 +59,7 @@ public class HandlerWrapper {
         return LambdaTracing.instrument(
                 input,
                 context,
-                (event, ctx) -> requestHandler.handleRequest(input, context)
+                requestHandler::handleRequest
         );
     }
 

--- a/java/src/main/java/com/newrelic/java/JavaClassLoader.java
+++ b/java/src/main/java/com/newrelic/java/JavaClassLoader.java
@@ -2,7 +2,6 @@ package com.newrelic.java;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.amazonaws.services.lambda.runtime.serialization.PojoSerializer;
 import com.amazonaws.services.lambda.runtime.serialization.events.LambdaEventSerializers;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -16,96 +15,103 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 
-public class JavaClassLoader {
+public class JavaClassLoader implements RequestHandler<Object, Object> {
 
-    private static final ClassLoader classLoader = JavaClassLoader.class.getClassLoader();
-    private static final MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
-    private static final MethodType methodType = MethodType.methodType(Object.class, Object.class, Context.class);
-    private static final ObjectMapper mapper = new ObjectMapper().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+    private interface UnsafeHandler {
+
+        Object handle(Object input, Context context) throws Throwable;
+
+    }
+
+    private final ObjectMapper mapper = new ObjectMapper().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .enable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
             .registerModule(new JodaModule());
 
-    private static Class inputType;
-    private static MethodHandle methodHandle;
-    private static RequestStreamHandler classInstance;
+    private final Class<?> inputType;
+    private final UnsafeHandler executor;
 
-    static JavaClassLoader initializeClass(String className, String methodName) throws ReflectiveOperationException {
-        Class loadedClass = classLoader.loadClass(className);
-        if (RequestStreamHandler.class.isAssignableFrom(loadedClass)) {
-            return initializeRequestStreamHandler(className, loadedClass);
-        }
-        return initializeRequestHandler(className, methodName, loadedClass);
-    }
-
-    // RequestStreamHandler implementation constructor
-    private JavaClassLoader(RequestStreamHandler classInstance) {
-        this.classInstance = classInstance;
-    }
-
-    // RequestStreamHandler initializeClassLoader
-    static JavaClassLoader initializeRequestStreamHandler(String className, Class loadedClass) throws ReflectiveOperationException {
-        RequestStreamHandler classInstance = (RequestStreamHandler) loadedClass.getDeclaredConstructor().newInstance();
-        return new JavaClassLoader(classInstance);
-    }
-
-    public static RequestStreamHandler getClassInstance() {
-        return classInstance;
-    }
-
-    // RequestHandler implementation constructor
-    private JavaClassLoader(Class inputType, MethodHandle methodHandle) {
-        this.inputType = inputType;
-        this.methodHandle = methodHandle;
-    }
-
-    // RequestHandler initializeClassLoader
-    static JavaClassLoader initializeRequestHandler(String className, String methodName, Class loadedClass) throws ReflectiveOperationException {
-        Class methodInputType = null;
+    static JavaClassLoader initializeRequestHandler(Class<?> loadedClass, String methodName) throws ReflectiveOperationException {
+        Class<?> methodReturnType = Object.class;
+        Class<?> methodInputType = Object.class;
+        Class<?> methodContextType = null;
         for (Method method : loadedClass.getMethods()) {
-            if (isUserHandlerMethod(method, className, methodName, loadedClass) == true) {
+            if (isUserHandlerMethod(method, methodName, loadedClass)) {
+                methodReturnType = method.getReturnType();
                 methodInputType = method.getParameterTypes()[0];
+                if (method.getParameterTypes().length == 2) {
+                    methodContextType = method.getParameterTypes()[1];
+                }
                 break;
             }
         }
+
         Object classInstance = loadedClass.getDeclaredConstructor().newInstance();
-        MethodHandle methodHandle = publicLookup.findVirtual(loadedClass, methodName, methodType).bindTo(classInstance);
-        return new JavaClassLoader(methodInputType, methodHandle);
+
+        MethodHandle methodHandle = MethodHandles.publicLookup().findVirtual(
+                loadedClass,
+                methodName,
+                getMethodType(methodReturnType, methodInputType, methodContextType)
+        ).bindTo(classInstance);
+
+        return new JavaClassLoader(methodInputType, methodHandle, methodContextType != null);
     }
 
-    public Object invokeClassMethod(Object inputParam, Context contextParam) {
-        Object handlerType = mappingInputToHandlerType(inputParam, inputType);
+    private static MethodType getMethodType(Class<?> methodReturnType, Class<?> methodInputType, Class<?> methodContextType) {
+        if (methodContextType == null) {
+            return MethodType.methodType(methodReturnType, methodInputType);
+        }
+        return MethodType.methodType(methodReturnType, methodInputType, methodContextType);
+    }
+
+    // RequestHandler implementation constructor
+    private JavaClassLoader(Class<?> inputType, MethodHandle methodHandle, boolean hasTwoArguments) {
+        this.inputType = inputType;
+        this.executor = hasTwoArguments
+                ? methodHandle::invokeWithArguments
+                : (handlerType, contextParam) -> methodHandle.invokeWithArguments(handlerType);
+    }
+
+    @Override
+    public Object handleRequest(Object inputParam, Context contextParam) {
         try {
-            return methodHandle.invokeWithArguments(handlerType, contextParam);
+            return executor.handle(mappingInputToHandlerType(inputParam, inputType), contextParam);
         } catch (Throwable e) {
             throw new RuntimeException("Error occurred while invoking handler method: " + e);
         }
     }
 
-    private static boolean isUserHandlerMethod(Method method, String className, String methodName, Class<?> loadedClass) {
-        if ((method.getDeclaringClass().getName().equals(className) || method.getDeclaringClass().isAssignableFrom(loadedClass)) &&
-                method.getName().equals(methodName) &&
-                method.getParameterTypes().length == 2 &&
-                !(method.isBridge() || method.isSynthetic()) &&
-                method.getParameterTypes()[1].isAssignableFrom(Context.class)) {
+    private static boolean isUserHandlerMethod(Method method, String methodName, Class<?> loadedClass) {
+        if (!method.getDeclaringClass().isAssignableFrom(loadedClass)) {
+            return false;
+        }
+
+        if (!method.getName().equals(methodName)) {
+            return false;
+        }
+
+        if (method.isBridge() || method.isSynthetic()) {
+            return false;
+        }
+
+        if (method.getParameterTypes().length == 1) {
             return true;
         }
-        return false;
+
+        return method.getParameterTypes().length == 2 && (
+                method.getParameterTypes()[1].isAssignableFrom(Context.class) || Object.class.equals(method.getParameterTypes()[1])
+        );
     }
 
-    private Object mappingInputToHandlerType(Object inputParam, Class inputType) {
+    private Object mappingInputToHandlerType(Object inputParam, Class<?> inputType) throws JsonProcessingException {
         if (inputType.isAssignableFrom(Number.class) || inputType.isAssignableFrom(String.class)) {
             return inputParam;
         } else if (LambdaEventSerializers.isLambdaSupportedEvent(inputType.getName())) {
-            try {
-                PojoSerializer serializer = LambdaEventSerializers.serializerFor(inputType, classLoader);
-                String inputParamString = mapper.writeValueAsString(inputParam);
-                return serializer.fromJson(inputParamString);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException("Error occurred while serializing lambda input type: " + e);
-            }
+            PojoSerializer<?> serializer = LambdaEventSerializers.serializerFor(inputType, JavaClassLoader.class.getClassLoader());
+            String inputParamString = mapper.writeValueAsString(inputParam);
+            return serializer.fromJson(inputParamString);
         }
-        return mapper.convertValue(inputParam, inputType);
+        return inputParam instanceof CharSequence ? mapper.readValue(inputParam.toString(), inputType) : mapper.convertValue(inputParam, inputType);
     }
 }
 

--- a/java/src/test/java/com/newrelic/java/BiFunctionHandlerWithObjectInput.java
+++ b/java/src/test/java/com/newrelic/java/BiFunctionHandlerWithObjectInput.java
@@ -1,0 +1,16 @@
+package com.newrelic.java;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+import java.util.function.BiFunction;
+
+public class BiFunctionHandlerWithObjectInput implements BiFunction<Input, Context, String> {
+
+    public static final String RESPONSE_PREFIX = "Hello ";
+
+    @Override
+    public String apply(Input s, Context context) {
+        return RESPONSE_PREFIX + s.getMessage();
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/BiFunctionHandlerWithStringInput.java
+++ b/java/src/test/java/com/newrelic/java/BiFunctionHandlerWithStringInput.java
@@ -1,0 +1,16 @@
+package com.newrelic.java;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+import java.util.function.BiFunction;
+
+public class BiFunctionHandlerWithStringInput implements BiFunction<String, Context, String> {
+
+    public static final String RESPONSE_PREFIX = "Hello ";
+
+    @Override
+    public String apply(String s, Context context) {
+        return RESPONSE_PREFIX + s;
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/FunctionHandlerWithObjectInput.java
+++ b/java/src/test/java/com/newrelic/java/FunctionHandlerWithObjectInput.java
@@ -1,0 +1,14 @@
+package com.newrelic.java;
+
+import java.util.function.Function;
+
+public class FunctionHandlerWithObjectInput implements Function<Input, String> {
+
+    public static final String RESPONSE_PREFIX = "Hello ";
+
+    @Override
+    public String apply(Input s) {
+        return RESPONSE_PREFIX + s.getMessage();
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/FunctionHandlerWithStringInput.java
+++ b/java/src/test/java/com/newrelic/java/FunctionHandlerWithStringInput.java
@@ -1,0 +1,14 @@
+package com.newrelic.java;
+
+import java.util.function.Function;
+
+public class FunctionHandlerWithStringInput implements Function<String, String> {
+
+    public static final String RESPONSE_PREFIX = "Hello ";
+
+    @Override
+    public String apply(String s) {
+        return RESPONSE_PREFIX + s;
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/HandlerWrapperTest.java
+++ b/java/src/test/java/com/newrelic/java/HandlerWrapperTest.java
@@ -1,0 +1,54 @@
+package com.newrelic.java;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class HandlerWrapperTest {
+
+    @Test
+    public void testRequestHandler() throws Exception {
+        SystemLambda.withEnvironmentVariable(HandlerWrapper.HANDLER_ENV_VAR, RequestHandlerWithObjectInput.class.getName())
+                .execute(() -> {
+                    HandlerWrapper.setupHandlers();
+                    assertEquals("Hello World", new HandlerWrapper().handleRequest(Input.create("World"), Mockito.mock(Context.class)));
+                });
+    }
+
+    @Test
+    public void testRequestWrongHandler() throws Exception {
+        SystemLambda.withEnvironmentVariable(HandlerWrapper.HANDLER_ENV_VAR, RequestHandlerWithObjectInput.class.getName())
+                .execute(() -> {
+                    HandlerWrapper.setupHandlers();
+                    assertThrows(RuntimeException.class, () ->
+                            new HandlerWrapper().handleStreamsRequest(Mockito.mock(InputStream.class), Mockito.mock(OutputStream.class), Mockito.mock(Context.class))
+                    );
+                });
+    }
+
+    @Test
+    public void testRequestStreamHandler() throws Exception {
+        SystemLambda.withEnvironmentVariable(HandlerWrapper.HANDLER_ENV_VAR, TestStreamingRequestHandler.class.getName())
+                .execute(() -> {
+                    HandlerWrapper.setupHandlers();
+                    new HandlerWrapper().handleStreamsRequest(Mockito.mock(InputStream.class), Mockito.mock(OutputStream.class), Mockito.mock(Context.class));
+                });
+    }
+
+    @Test
+    public void testRequestWrongStreamHandler() throws Exception {
+        SystemLambda.withEnvironmentVariable(HandlerWrapper.HANDLER_ENV_VAR, TestStreamingRequestHandler.class.getName())
+                .execute(() -> {
+                    HandlerWrapper.setupHandlers();
+                    assertThrows(RuntimeException.class, () -> new HandlerWrapper().handleRequest(Input.create("World"), Mockito.mock(Context.class)));
+                });
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/Input.java
+++ b/java/src/test/java/com/newrelic/java/Input.java
@@ -1,0 +1,20 @@
+package com.newrelic.java;
+
+public class Input {
+
+    public static Input create(String message) {
+        Input input = new Input();
+        input.setMessage(message);
+        return input;
+    }
+
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/java/src/test/java/com/newrelic/java/JavaClassLoaderTest.java
+++ b/java/src/test/java/com/newrelic/java/JavaClassLoaderTest.java
@@ -1,0 +1,54 @@
+package com.newrelic.java;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JavaClassLoaderTest {
+
+    private static final String INPUT_AS_STRING = "{\"message\": \"World\"}";
+    private static final Input INPUT_AS_OBJECT = Input.create("World");
+    public static final String STRING_INPUT = "World";
+
+    @Test
+    public void testFunctionWithObjectHandler() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(FunctionHandlerWithObjectInput.class, "apply");
+        Assert.assertEquals("Hello World", loader.handleRequest(INPUT_AS_OBJECT, null));
+    }
+
+    @Test
+    public void testFunctionWithObjectHandlerPassedAsJson() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(FunctionHandlerWithObjectInput.class, "apply");
+        Assert.assertEquals("Hello World", loader.handleRequest(INPUT_AS_STRING, null));
+    }
+
+    @Test
+    public void testFunctionWithStringHandler() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(FunctionHandlerWithStringInput.class, "apply");
+        Assert.assertEquals("Hello World", loader.handleRequest(STRING_INPUT, null));
+    }
+
+    @Test
+    public void testBiFunctionWithObjectHandler() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(BiFunctionHandlerWithObjectInput.class, "apply");
+        Assert.assertEquals("Hello World", loader.handleRequest(INPUT_AS_OBJECT, null));
+    }
+
+    @Test
+    public void testBiFunctionWithStringHandler() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(BiFunctionHandlerWithStringInput.class, "apply");
+        Assert.assertEquals("Hello World", loader.handleRequest(STRING_INPUT, null));
+    }
+
+    @Test
+    public void testWithObjectRequestHandler() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(RequestHandlerWithObjectInput.class, "handleRequest");
+        Assert.assertEquals("Hello World", loader.handleRequest(INPUT_AS_OBJECT, null));
+    }
+
+    @Test
+    public void testWithStringRequestHandler() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(RequestHandlerWithStringInput.class, "handleRequest");
+        Assert.assertEquals("Hello World", loader.handleRequest(STRING_INPUT, null));
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/RequestHandlerWithObjectInput.java
+++ b/java/src/test/java/com/newrelic/java/RequestHandlerWithObjectInput.java
@@ -1,0 +1,15 @@
+package com.newrelic.java;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class RequestHandlerWithObjectInput implements RequestHandler<Input, String> {
+
+    public static final String RESPONSE_PREFIX = "Hello ";
+
+    @Override
+    public String handleRequest(Input s, Context context) {
+        return RESPONSE_PREFIX + s.getMessage();
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/RequestHandlerWithStringInput.java
+++ b/java/src/test/java/com/newrelic/java/RequestHandlerWithStringInput.java
@@ -1,0 +1,15 @@
+package com.newrelic.java;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class RequestHandlerWithStringInput implements RequestHandler<String, String> {
+
+    public static final String RESPONSE_PREFIX = "Hello ";
+
+    @Override
+    public String handleRequest(String s, Context context) {
+        return RESPONSE_PREFIX + s;
+    }
+
+}

--- a/java/src/test/java/com/newrelic/java/TestStreamingRequestHandler.java
+++ b/java/src/test/java/com/newrelic/java/TestStreamingRequestHandler.java
@@ -1,0 +1,15 @@
+package com.newrelic.java;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class TestStreamingRequestHandler implements RequestStreamHandler {
+    @Override
+    public void handleRequest(InputStream input, OutputStream output, Context context) {
+        // do nothing
+    }
+}


### PR DESCRIPTION
The current Java implementation is very restrictive in terms of the method signatures. At least the following use cases are not covered

1. the handler method does not accept `Context`
2. the handler method does accept `Context` as bounded parameter
3. the input type is not `Object` or generic type parameter

Some design flaws has been also fixed:
1. The extensive usage of static fields
2. Dual functionality of `JavaClassPath` object
3. The naming of `JavaClassPath` class was not descriptive

Tests were added to cover the most common use cases.

Fixes #50.