### PR TITLE
Dockerize Node Layer Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,40 +2,20 @@ version: 2
 
 jobs:
   publish-nodejs12x:
-    docker:
-        - image: circleci/node:12
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install -y groff less
-      - run:
-          name: Install publish dependencies
-          command: |
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            sudo ./aws/install
+      - setup_remote_docker
       - run:
           name: Publish layer
-          command: |
-            cd nodejs
-            ./publish-layers.sh nodejs12.x
+          command: make publish-nodejs12x-ci
 
   publish-nodejs14x:
-    docker:
-        - image: circleci/node:14
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install -y groff less
-      - run:
-          name: Install publish dependencies
-          command: |
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            sudo ./aws/install
+      - setup_remote_docker
       - run:
           name: Publish layer
-          command: |
-            cd nodejs
-            ./publish-layers.sh nodejs14.x
+          command: make publish-nodejs14x-ci
 
   publish-python36:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+build-nodejs12x:
+	docker build \
+		--no-cache \
+		-t newrelic-lambda-layers-nodejs12x \
+		-f ./dockerfiles/Dockerfile.nodejs12x \
+		.
+
+publish-nodejs12x-ci: build-nodejs12x
+	docker run \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		newrelic-lambda-layers-nodejs12x
+
+publish-nodejs12x-local: build-nodejs12x
+	docker run \
+		-e AWS_PROFILE \
+		-v "${HOME}/.aws:/home/newrelic-lambda-layers/.aws" \
+		newrelic-lambda-layers-nodejs12x
+
+build-nodejs14x:
+	docker build \
+		--no-cache \
+		-t newrelic-lambda-layers-nodejs14x \
+		-f ./dockerfiles/Dockerfile.nodejs14x \
+		.
+
+publish-nodejs14x-ci: build-nodejs14x
+	docker run \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		newrelic-lambda-layers-nodejs14x
+
+publish-nodejs14x-local: build-nodejs14x
+	docker run \
+		-e AWS_PROFILE \
+		-v "${HOME}/.aws:/home/newrelic-lambda-layers/.aws" \
+		newrelic-lambda-layers-nodejs14x

--- a/dockerfiles/Dockerfile.nodejs12x
+++ b/dockerfiles/Dockerfile.nodejs12x
@@ -1,0 +1,25 @@
+FROM node:12 as builder
+
+RUN apt-get update \
+    && apt-get install -y curl unzip zip
+
+RUN useradd -r newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+
+COPY nodejs .
+
+RUN ./publish-layers.sh build-nodejs12x
+
+FROM python:3.8
+
+RUN useradd -r newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+RUN pip3 install -U awscli --user
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH  
+
+COPY nodejs .
+COPY --from=builder /home/newrelic-lambda-layers/dist dist
+
+CMD ./publish-layers.sh publish-nodejs12x

--- a/dockerfiles/Dockerfile.nodejs14x
+++ b/dockerfiles/Dockerfile.nodejs14x
@@ -1,0 +1,25 @@
+FROM node:14 as builder
+
+RUN apt-get update \
+    && apt-get install -y curl unzip zip
+
+RUN useradd -r newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+
+COPY nodejs .
+
+RUN ./publish-layers.sh build-nodejs14x
+
+FROM python:3.8
+
+RUN useradd -r newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+RUN pip3 install -U awscli --user
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH  
+
+COPY nodejs .
+COPY --from=builder /home/newrelic-lambda-layers/dist dist
+
+CMD ./publish-layers.sh publish-nodejs14x

--- a/nodejs/publish-layers.sh
+++ b/nodejs/publish-layers.sh
@@ -99,11 +99,10 @@ function publish-nodejs12x-arm64 {
 		bucket_name="${BUCKET_PREFIX}-${region}"
 
 		echo "Uploading ${NJS12X_DIST_ARM64} to s3://${bucket_name}/${njs12x_s3key}"
-		aws --debug --region "$region" s3 cp $NJS12X_DIST_ARM64 "s3://${bucket_name}/${njs12x_s3key}"
+		aws --region "$region" s3 cp $NJS12X_DIST_ARM64 "s3://${bucket_name}/${njs12x_s3key}"
 
 		echo "Publishing nodejs12.x layer to ${region}"
 		njs12x_version=$(aws lambda publish-layer-version \
-			--debug \
 			--layer-name NewRelicNodeJS12XARM64 \
 			--content "S3Bucket=${bucket_name},S3Key=${njs12x_s3key}" \
 			--description "New Relic Layer for Node.js 12.x (arm64)" \
@@ -117,7 +116,6 @@ function publish-nodejs12x-arm64 {
 
 		echo "Setting public permissions for nodejs12.x layer version ${njs12x_version} in ${region}"
 		aws lambda add-layer-version-permission \
-			--debug \
 			--layer-name NewRelicNodeJS12XARM64 \
 			--version-number "$njs12x_version" \
 			--statement-id public \
@@ -141,11 +139,10 @@ function publish-nodejs12x-x86 {
 		bucket_name="${BUCKET_PREFIX}-${region}"
 
 		echo "Uploading ${NJS12X_DIST_X86_64} to s3://${bucket_name}/${njs12x_s3key}"
-		aws --debug --region "$region" s3 cp $NJS12X_DIST_X86_64 "s3://${bucket_name}/${njs12x_s3key}"
+		aws --region "$region" s3 cp $NJS12X_DIST_X86_64 "s3://${bucket_name}/${njs12x_s3key}"
 
 		echo "Publishing nodejs12.x layer to ${region}"
 		njs12x_version=$(aws lambda publish-layer-version \
-			--debug \
 			--layer-name NewRelicNodeJS12X \
 			--content "S3Bucket=${bucket_name},S3Key=${njs12x_s3key}" \
 			--description "New Relic Layer for Node.js 12.x (x86_64)" \
@@ -159,7 +156,6 @@ function publish-nodejs12x-x86 {
 
 		echo "Setting public permissions for nodejs12.x layer version ${njs12x_version} in ${region}"
 		aws lambda add-layer-version-permission \
-			--debug \
 			--layer-name NewRelicNodeJS12X \
 			--version-number "$njs12x_version" \
 			--statement-id public \
@@ -174,11 +170,10 @@ function publish-nodejs12x-x86 {
 		bucket_name="${BUCKET_PREFIX}-${region}"
 
 		echo "Uploading ${NJS12X_DIST_X86_64} to s3://${bucket_name}/${njs12x_s3key}"
-		aws --debug --region "$region" s3 cp $NJS12X_DIST_X86_64 "s3://${bucket_name}/${njs12x_s3key}"
+		aws --region "$region" s3 cp $NJS12X_DIST_X86_64 "s3://${bucket_name}/${njs12x_s3key}"
 
 		echo "Publishing nodejs12.x layer to ${region}"
 		njs12x_version=$(aws lambda publish-layer-version \
-			--debug \
 			--layer-name NewRelicNodeJS12X \
 			--content "S3Bucket=${bucket_name},S3Key=${njs12x_s3key}" \
 			--description "New Relic Layer for Node.js 12.x (x86_64)" \
@@ -191,7 +186,6 @@ function publish-nodejs12x-x86 {
 
 		echo "Setting public permissions for nodejs12.x layer version ${njs12x_version} in ${region}"
 		aws lambda add-layer-version-permission \
-			--debug \
 			--layer-name NewRelicNodeJS12X \
 			--version-number "$njs12x_version" \
 			--statement-id public \
@@ -241,11 +235,10 @@ function publish-nodejs14x-arm64 {
 		bucket_name="${BUCKET_PREFIX}-${region}"
 
 		echo "Uploading ${NJS14X_DIST_ARM64} to s3://${bucket_name}/${njs14x_s3key}"
-		aws --debug --region "$region" s3 cp $NJS14X_DIST_ARM64 "s3://${bucket_name}/${njs14x_s3key}"
+		aws --region "$region" s3 cp $NJS14X_DIST_ARM64 "s3://${bucket_name}/${njs14x_s3key}"
 
 		echo "Publishing nodejs14.x layer to ${region}"
 		njs14x_version=$(aws lambda publish-layer-version \
-			--debug \
 			--layer-name NewRelicNodeJS14XARM64 \
 			--content "S3Bucket=${bucket_name},S3Key=${njs14x_s3key}" \
 			--description "New Relic Layer for Node.js 14.x (arm64)" \
@@ -259,7 +252,6 @@ function publish-nodejs14x-arm64 {
 
 		echo "Setting public permissions for nodejs14.x layer version ${njs14x_version} in ${region}"
 		aws lambda add-layer-version-permission \
-			--debug \
 			--layer-name NewRelicNodeJS14XARM64 \
 			--version-number "$njs14x_version" \
 			--statement-id public \
@@ -283,11 +275,10 @@ function publish-nodejs14x-x86 {
 		bucket_name="${BUCKET_PREFIX}-${region}"
 
 		echo "Uploading ${NJS14X_DIST_X86_64} to s3://${bucket_name}/${njs14x_s3key}"
-		aws --debug --region "$region" s3 cp $NJS14X_DIST_X86_64 "s3://${bucket_name}/${njs14x_s3key}"
+		aws --region "$region" s3 cp $NJS14X_DIST_X86_64 "s3://${bucket_name}/${njs14x_s3key}"
 
 		echo "Publishing nodejs14.x layer to ${region}"
 		njs14x_version=$(aws lambda publish-layer-version \
-			--debug \
 			--layer-name NewRelicNodeJS14X \
 			--content "S3Bucket=${bucket_name},S3Key=${njs14x_s3key}" \
 			--description "New Relic Layer for Node.js 14.x (x86_64)" \
@@ -301,7 +292,6 @@ function publish-nodejs14x-x86 {
 
 		echo "Setting public permissions for nodejs14.x layer version ${njs14x_version} in ${region}"
 		aws lambda add-layer-version-permission \
-			--debug \
 			--layer-name NewRelicNodeJS14X \
 			--version-number "$njs14x_version" \
 			--statement-id public \
@@ -316,11 +306,10 @@ function publish-nodejs14x-x86 {
 		bucket_name="${BUCKET_PREFIX}-${region}"
 
 		echo "Uploading ${NJS14X_DIST_X86_64} to s3://${bucket_name}/${njs14x_s3key}"
-		aws --debug --region "$region" s3 cp $NJS14X_DIST_X86_64 "s3://${bucket_name}/${njs14x_s3key}"
+		aws --region "$region" s3 cp $NJS14X_DIST_X86_64 "s3://${bucket_name}/${njs14x_s3key}"
 
 		echo "Publishing nodejs14.x layer to ${region}"
 		njs14x_version=$(aws lambda publish-layer-version \
-			--debug \
 			--layer-name NewRelicNodeJS14X \
 			--content "S3Bucket=${bucket_name},S3Key=${njs14x_s3key}" \
 			--description "New Relic Layer for Node.js 14.x (x86_64)" \
@@ -333,7 +322,6 @@ function publish-nodejs14x-x86 {
 
 		echo "Setting public permissions for nodejs14.x layer version ${njs14x_version} in ${region}"
 		aws lambda add-layer-version-permission \
-			--debug \
 			--layer-name NewRelicNodeJS14X \
 			--version-number "$njs14x_version" \
 			--statement-id public \
@@ -345,19 +333,29 @@ function publish-nodejs14x-x86 {
 }
 
 case "$1" in
-"nodejs12.x")
+"build-nodejs12x")
 	build-nodejs12x-arm64
-	publish-nodejs12x-arm64
-
 	build-nodejs12x-x86
+	;;
+"publish-nodejs12x")
+	publish-nodejs12x-arm64
 	publish-nodejs12x-x86
 	;;
-"nodejs14.x")
+"build-nodejs14x")
 	build-nodejs14x-arm64
-	publish-nodejs14x-arm64
-
 	build-nodejs14x-x86
+	;;
+"publish-nodejs14x")
+	publish-nodejs14x-arm64
 	publish-nodejs14x-x86
+	;;
+"nodejs12x")
+	$0 build-nodejs12.x
+	$0 publish-nodejs12.x
+	;;
+"nodejs14x")
+	$0 build-nodejs14x
+	$0 publish-nodejs14x
 	;;
 *)
 	usage


### PR DESCRIPTION
All layers should be built and published in their own containers. This gets the ball rolling.