### PR TITLE
fix: Including tracer deps by building with runtimeClasspath

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -28,7 +28,7 @@ def extensions = copySpec {
 task packageLayer(type: Zip) {
     archiveBaseName = 'NewRelicJavaLayer'
     into('java/lib') {
-        from configurations.compileClasspath
+        from configurations.runtimeClasspath
     }
     into('java/lib') {
         from fileTree('build/libs') {


### PR DESCRIPTION
This fixes the missing tracer dependencies in the Java layer without needing to add them explicitly.

Signed-off-by: mrickard <maurice@mauricerickard.com>