### PR TITLE
Adjust dockerfile build to preserve dir structure

### DIFF
--- a/dockerfiles/Dockerfile.java11
+++ b/dockerfiles/Dockerfile.java11
@@ -7,8 +7,10 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY java .
+COPY libBuild.sh .
+COPY java java/
 
+WORKDIR java
 RUN ./publish-layers.sh build-java11
 
 FROM python:3.8
@@ -17,9 +19,11 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 RUN pip3 install -U awscli --user
-ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH  
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH
 
-COPY java .
-COPY --from=builder /home/newrelic-lambda-layers/dist dist
+COPY libBuild.sh .
+COPY java java/
+COPY --from=builder /home/newrelic-lambda-layers/java/dist dist
 
+WORKDIR java
 CMD ./publish-layers.sh publish-java11

--- a/dockerfiles/Dockerfile.java8al2
+++ b/dockerfiles/Dockerfile.java8al2
@@ -7,8 +7,10 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY java .
+COPY libBuild.sh .
+COPY java java/
 
+WORKDIR java
 RUN ./publish-layers.sh build-java8al2
 
 FROM python:3.8
@@ -17,9 +19,11 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 RUN pip3 install -U awscli --user
-ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH  
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH
 
-COPY java .
-COPY --from=builder /home/newrelic-lambda-layers/dist dist
+COPY libBuild.sh .
+COPY java java/
+COPY --from=builder /home/newrelic-lambda-layers/java/dist dist
 
+WORKDIR java
 CMD ./publish-layers.sh publish-java8al2

--- a/dockerfiles/Dockerfile.nodejs12x
+++ b/dockerfiles/Dockerfile.nodejs12x
@@ -7,8 +7,10 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY nodejs .
+COPY libBuild.sh .
+COPY nodejs nodejs/
 
+WORKDIR nodejs
 RUN ./publish-layers.sh build-nodejs12x
 
 FROM python:3.8
@@ -17,9 +19,11 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 RUN pip3 install -U awscli --user
-ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH  
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH
 
-COPY nodejs .
-COPY --from=builder /home/newrelic-lambda-layers/dist dist
+COPY libBuild.sh .
+COPY nodejs nodejs/
+COPY --from=builder /home/newrelic-lambda-layers/nodejs/dist nodejs/dist
 
+WORKDIR nodejs
 CMD ./publish-layers.sh publish-nodejs12x

--- a/dockerfiles/Dockerfile.nodejs14x
+++ b/dockerfiles/Dockerfile.nodejs14x
@@ -7,8 +7,10 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY nodejs .
+COPY libBuild.sh .
+COPY nodejs nodejs/
 
+WORKDIR nodejs
 RUN ./publish-layers.sh build-nodejs14x
 
 FROM python:3.8
@@ -17,9 +19,11 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 RUN pip3 install -U awscli --user
-ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH  
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH
 
-COPY nodejs .
-COPY --from=builder /home/newrelic-lambda-layers/dist dist
+COPY libBuild.sh .
+COPY nodejs nodejs/
+COPY --from=builder /home/newrelic-lambda-layers/nodejs/dist nodejs/dist
 
+WORKDIR nodejs
 CMD ./publish-layers.sh publish-nodejs14x


### PR DESCRIPTION
Docker build was flattening the dir structure, which broke when I started referring to files in the parent dir.