### PR TITLE
file ownership fix

### DIFF
--- a/dockerfiles/Dockerfile.java11
+++ b/dockerfiles/Dockerfile.java11
@@ -7,8 +7,8 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY libBuild.sh .
-COPY java java/
+COPY --chown=newrelic-lambda-layers libBuild.sh .
+COPY --chown=newrelic-lambda-layers java java/
 
 WORKDIR java
 RUN ./publish-layers.sh build-java11

--- a/dockerfiles/Dockerfile.java8al2
+++ b/dockerfiles/Dockerfile.java8al2
@@ -7,8 +7,8 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY libBuild.sh .
-COPY java java/
+COPY --chown=newrelic-lambda-layers libBuild.sh .
+COPY --chown=newrelic-lambda-layers java java/
 
 WORKDIR java
 RUN ./publish-layers.sh build-java8al2

--- a/dockerfiles/Dockerfile.nodejs12x
+++ b/dockerfiles/Dockerfile.nodejs12x
@@ -7,8 +7,8 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY libBuild.sh .
-COPY nodejs nodejs/
+COPY --chown=newrelic-lambda-layers libBuild.sh .
+COPY --chown=newrelic-lambda-layers nodejs nodejs/
 
 WORKDIR nodejs
 RUN ./publish-layers.sh build-nodejs12x

--- a/dockerfiles/Dockerfile.nodejs14x
+++ b/dockerfiles/Dockerfile.nodejs14x
@@ -7,8 +7,8 @@ RUN useradd -m newrelic-lambda-layers
 USER newrelic-lambda-layers
 WORKDIR /home/newrelic-lambda-layers
 
-COPY libBuild.sh .
-COPY nodejs nodejs/
+COPY --chown=newrelic-lambda-layers libBuild.sh .
+COPY --chown=newrelic-lambda-layers nodejs nodejs/
 
 WORKDIR nodejs
 RUN ./publish-layers.sh build-nodejs14x


### PR DESCRIPTION
For some reason, we've chosen to create a new user within the container to run the build, but the docker `COPY` defaults to root ownership, which creates problems.