### PR TITLE
fix: Adding circleCi job for Node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,16 @@ jobs:
           name: Publish layer
           command: make publish-nodejs14x-ci
 
+  publish-nodejs16x:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Publish layer
+          command: make publish-nodejs16x-ci
+
   publish-python36:
     docker:
       - image: circleci/python:3.6


### PR DESCRIPTION
Need to add this for Node 16 layers to be built

Signed-off-by: mrickard <maurice@mauricerickard.com>