### PR TITLE
fix: Adding Node 16 build jobs to the CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,12 @@ workflows:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*_nodejs/
+      - publish-nodejs16x:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*_nodejs/
       - publish-python36:
           filters:
             branches:


### PR DESCRIPTION
Yet another step before the Node 16 jobs can run.

Signed-off-by: mrickard <maurice@mauricerickard.com>