### PR TITLE
fix: Using current cimg/node images for Node builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   publish-nodejs12x:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/node:12.22.12
     steps:
       - checkout
       - setup_remote_docker
@@ -13,7 +13,7 @@ jobs:
 
   publish-nodejs14x:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/node:14.19.3
     steps:
       - checkout
       - setup_remote_docker
@@ -23,7 +23,7 @@ jobs:
 
   publish-nodejs16x:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/node:16.15.0
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
circleci-prefix images [were deprecated in 2021](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034); the python 3.8 image can't find a Node 16 dockerfile. So let's use the most recent images.

Signed-off-by: mrickard <maurice@mauricerickard.com>