### PR TITLE
build(nodejs): add missing node16 runtime dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.nodejs16x
+++ b/dockerfiles/Dockerfile.nodejs16x
@@ -1,0 +1,29 @@
+FROM node:16 as builder
+
+RUN apt-get update \
+    && apt-get install -y curl unzip zip
+
+RUN useradd -m newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+
+COPY --chown=newrelic-lambda-layers libBuild.sh .
+COPY --chown=newrelic-lambda-layers nodejs nodejs/
+
+WORKDIR nodejs
+RUN ./publish-layers.sh build-nodejs16x
+
+FROM python:3.8
+
+RUN useradd -m newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+RUN pip3 install -U awscli --user
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH
+
+COPY libBuild.sh .
+COPY nodejs nodejs/
+COPY --from=builder /home/newrelic-lambda-layers/nodejs/dist nodejs/dist
+
+WORKDIR nodejs
+CMD ./publish-layers.sh publish-nodejs16x


### PR DESCRIPTION
The node16 build and publish is failing due to referencing a dockerfile for node 16 which doesn't
exist. This PR adds that dockerfile.

fix #85