### PR TITLE
Added the original error as a cause

### DIFF
--- a/java/src/main/java/com/newrelic/java/HandlerWrapper.java
+++ b/java/src/main/java/com/newrelic/java/HandlerWrapper.java
@@ -52,7 +52,7 @@ public class HandlerWrapper {
                     };
 
         } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Error occurred during initialization of javaClassLoader: " + e);
+            throw new RuntimeException("Error occurred during initialization of javaClassLoader!", e);
         }
     }
 

--- a/java/src/main/java/com/newrelic/java/HandlerWrapper.java
+++ b/java/src/main/java/com/newrelic/java/HandlerWrapper.java
@@ -52,7 +52,7 @@ public class HandlerWrapper {
                     };
 
         } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Error occurred during initialization of javaClassLoader!", e);
+            throw new RuntimeException("Error occurred during initialization of javaClassLoader:", e);
         }
     }
 


### PR DESCRIPTION
To expose the more details about the issue. The current implementation hides the problem underneath and we need to disable the handler and replace it with the original handler to figure out what is wrong. This change will help a lot to debug issues.