### PR TITLE
fix: Handler definition now uses handler index

### DIFF
--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -29,7 +29,7 @@ function getHandler() {
     )
   }
 
-  const handlerToWrap = parts.at(-1)
+  const handlerToWrap = parts[parts.length - 1]
   const moduleToImport = handler.slice(0, handler.lastIndexOf('.'))
 
   let importedModule


### PR DESCRIPTION
.at() as an array accessor method was added in Node 16, so Node 14 encountered an error.

Closes #101 

Signed-off-by: mrickard <maurice@mauricerickard.com>