### PR TITLE
Added documentation for ESM instrumentation in Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ These steps will help you configure the layers correctly:
 
 Refer to the [New Relic AWS Lambda Monitoring Documentation](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda) for instructions on completing your configuration by linking your AWS Account and Cloudwatch Log Streams to New Relic.
 
-## Support for ECMAScript Modules
+## Support for ES Modules
 
 As of October 2022, AWS supports ECMAScript in Lambda and ECMAScript modules as dependencies, but those functions do not yet support loading dependencies from Lambda Layers, as [`import` specifiers don't resolve with `NODE_PATH`](https://nodejs.org/docs/latest-v16.x/api/esm.html#no-node_path). 
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ These steps will help you configure the layers correctly:
 
 Refer to the [New Relic AWS Lambda Monitoring Documentation](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda) for instructions on completing your configuration by linking your AWS Account and Cloudwatch Log Streams to New Relic.
 
-## Support for ES Modules
+## Support for ES Modules (Node.js)
 
-As of October 2022, AWS supports ECMAScript in Lambda and ECMAScript modules as dependencies, but those functions do not yet support loading dependencies from Lambda Layers, as [`import` specifiers don't resolve with `NODE_PATH`](https://nodejs.org/docs/latest-v16.x/api/esm.html#no-node_path). 
+In January 2022, AWS announced support for ECMAScript in Lambda and ECMAScript modules as dependencies. The New Relic Node Agent introduced experimental support for ES Modules in version 9.1.0. Unfortunately, Lambda functions do not yet support loading ES Module dependencies from Lambda Layers, as [`import` specifiers don't resolve with `NODE_PATH`](https://nodejs.org/docs/latest-v16.x/api/esm.html#no-node_path). 
 
 If your Lambda functions are written using ES modules, you can still instrument them with New Relic, but you will need to do the following: 
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Refer to the [New Relic AWS Lambda Monitoring Documentation](https://docs.newrel
 
 As of October 2022, AWS supports ECMAScript in Lambda and ECMAScript modules as dependencies, but those functions do not yet support loading dependencies from Lambda Layers, as [`import` specifiers don't resolve with `NODE_PATH`](https://nodejs.org/docs/latest-v16.x/api/esm.html#no-node_path). 
 
-If your Lambda functions support ESM, you can still instrument them with New Relic, but you will need to do the following: 
+If your Lambda functions are written using ES modules, you can still instrument them with New Relic, but you will need to do the following: 
 
 1. [instrument your function manually](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy#node) using our [Node Agent](https://github.com/newrelic/node-newrelic/)  
 2. On deploying your function, don't set the function handler to our Node wrapper; instead, use your regular handler function, which you've wrapped with `newrelic.setLambdaHandler()`. 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,16 @@ These steps will help you configure the layers correctly:
   * NEW_RELIC_LAMBDA_HANDLER: Path to your initial handler.
 
 Refer to the [New Relic AWS Lambda Monitoring Documentation](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda) for instructions on completing your configuration by linking your AWS Account and Cloudwatch Log Streams to New Relic.
+
+## Support for ECMAScript Modules
+
+As of October 2022, AWS supports ECMAScript in Lambda and ECMAScript modules as dependencies, but those functions do not yet support loading dependencies from Lambda Layers, as [`import` specifiers don't resolve with `NODE_PATH`](https://nodejs.org/docs/latest-v16.x/api/esm.html#no-node_path). 
+
+If your Lambda functions support ESM, you can still instrument them with New Relic, but you will need to do the following: 
+
+1. [instrument your function manually](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy#node) using our [Node Agent](https://github.com/newrelic/node-newrelic/)  
+2. On deploying your function, don't set the function handler to our Node wrapper; instead, use your regular handler function, which you've wrapped with `newrelic.setLambdaHandler()`. 
+3. Install our Extension-only Lambda Layer for delivering telemetry. Use our [layer discovery website](https://layers.newrelic-external.com/) to find the ARN for your region. Look for either NewRelicLambdaExtension or NewRelicLambdaExtensionARM64 (depending on your function's architecture). 
+4. Add your `NEW_RELIC_LICENSE_KEY` as an environment variable.
+
+You may see some warnings from the Extension in CloudWatch logs referring to a non-standard handler; these may be ignored, since you've wrapped manually.


### PR DESCRIPTION
As AWS support for ECMAScript modules in Lambda doesn't extend to Lambda Layers, this documents one possible way of instrumenting.

Signed-off-by: mrickard <maurice@mauricerickard.com>