### PR TITLE
build(nodejs): add support for node18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,19 @@ jobs:
           name: Publish layer
           command: make publish-nodejs16x-ci
 
+  publish-nodejs18x:
+    docker:
+      - image: circleci/node:18
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Node 18 unit tests
+          command: cd nodejs && npm run ciTest
+      - run:
+          name: Publish layer
+          command: make publish-nodejs18x-ci
+
   publish-python36:
     docker:
       - image: circleci/python:3.6
@@ -149,6 +162,19 @@ workflows:
             - codecov/upload:
                 file: ./nodejs/coverage/hidden-handler/lcov.info
                 flags: nodejs-16-hidden-handler
+      - publish-nodejs18x:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*_nodejs/
+          post-steps:
+            - codecov/upload:
+                file: ./nodejs/coverage/handler/lcov.info
+                flags: nodejs-18-handler
+            - codecov/upload:
+                file: ./nodejs/coverage/hidden-handler/lcov.info
+                flags: nodejs-18-hidden-handler
       - publish-python36:
           filters:
             branches:

--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,22 @@ publish-nodejs16x-local: build-nodejs16x
 		-e AWS_PROFILE \
 		-v "${HOME}/.aws:/home/newrelic-lambda-layers/.aws" \
 		newrelic-lambda-layers-nodejs16x
+
+build-nodejs18x:
+	docker build \
+		--no-cache \
+		-t newrelic-lambda-layers-nodejs18x \
+		-f ./dockerfiles/Dockerfile.nodejs18x \
+		.
+
+publish-nodejs18x-ci: build-nodejs18x
+	docker run \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		newrelic-lambda-layers-nodejs18x
+
+publish-nodejs18x-local: build-nodejs18x
+	docker run \
+		-e AWS_PROFILE \
+		-v "${HOME}/.aws:/home/newrelic-lambda-layers/.aws" \
+		newrelic-lambda-layers-nodejs18x

--- a/dockerfiles/Dockerfile.nodejs18x
+++ b/dockerfiles/Dockerfile.nodejs18x
@@ -11,7 +11,7 @@ COPY --chown=newrelic-lambda-layers libBuild.sh .
 COPY --chown=newrelic-lambda-layers nodejs nodejs/
 
 WORKDIR nodejs
-RUN ./publish-layers.sh build-nodejs16x
+RUN ./publish-layers.sh build-nodejs18x
 
 FROM python:3.8
 
@@ -26,4 +26,4 @@ COPY nodejs nodejs/
 COPY --from=builder /home/newrelic-lambda-layers/nodejs/dist nodejs/dist
 
 WORKDIR nodejs
-CMD ./publish-layers.sh publish-nodejs16x
+CMD ./publish-layers.sh publish-nodejs18x

--- a/dockerfiles/Dockerfile.nodejs18x
+++ b/dockerfiles/Dockerfile.nodejs18x
@@ -1,0 +1,29 @@
+FROM node:18 as builder
+
+RUN apt-get update \
+    && apt-get install -y curl unzip zip
+
+RUN useradd -m newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+
+COPY --chown=newrelic-lambda-layers libBuild.sh .
+COPY --chown=newrelic-lambda-layers nodejs nodejs/
+
+WORKDIR nodejs
+RUN ./publish-layers.sh build-nodejs16x
+
+FROM python:3.8
+
+RUN useradd -m newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+RUN pip3 install -U awscli --user
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH
+
+COPY libBuild.sh .
+COPY nodejs nodejs/
+COPY --from=builder /home/newrelic-lambda-layers/nodejs/dist nodejs/dist
+
+WORKDIR nodejs
+CMD ./publish-layers.sh publish-nodejs16x

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -98,6 +98,9 @@ function layer_name_str() {
     "nodejs16.x")
       rt_part="NodeJS16X"
       ;;
+    "nodejs18.x")
+      rt_part="NodeJS18X"
+      ;;
     esac
 
     case $2 in
@@ -139,6 +142,9 @@ function s3_prefix() {
       ;;
     "nodejs16.x")
       name="nr-nodejs16.x"
+      ;;
+    "nodejs18.x")
+      name="nr-nodejs18.x"
       ;;
     esac
 

--- a/nodejs/publish-layers.sh
+++ b/nodejs/publish-layers.sh
@@ -9,12 +9,14 @@ source ../libBuild.sh
 
 NJS14X_DIST_ARM64=$DIST_DIR/nodejs14x.arm64.zip
 NJS16X_DIST_ARM64=$DIST_DIR/nodejs16x.arm64.zip
+NJS18X_DIST_ARM64=$DIST_DIR/nodejs18x.arm64.zip
 
 NJS14X_DIST_X86_64=$DIST_DIR/nodejs14x.x86_64.zip
 NJS16X_DIST_X86_64=$DIST_DIR/nodejs16x.x86_64.zip
+NJS18X_DIST_X86_64=$DIST_DIR/nodejs18x.x86_64.zip
 
 function usage {
-  	echo "./publish-layers.sh [nodejs14x|nodejs16x]"
+  	echo "./publish-layers.sh [nodejs14x|nodejs16x|nodejs18x]"
 }
 
 function build-nodejs14x-arm64 {
@@ -113,6 +115,54 @@ function publish-nodejs16x-x86 {
     done
 }
 
+function build-nodejs18x-arm64 {
+	echo "Building new relic layer for nodejs18.x (arm64)"
+	rm -rf $BUILD_DIR $NJS18X_DIST_ARM64
+	mkdir -p $DIST_DIR
+	npm install --prefix $BUILD_DIR newrelic@latest
+	mkdir -p $BUILD_DIR/node_modules/newrelic-lambda-wrapper
+	cp index.js $BUILD_DIR/node_modules/newrelic-lambda-wrapper
+	download_extension arm64
+	zip -rq $NJS18X_DIST_ARM64 $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+	rm -rf $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+	echo "Build complete: ${NJS18X_DIST_ARM64}"
+}
+
+function build-nodejs18x-x86 {
+	echo "Building new relic layer for nodejs18.x (x86_64)"
+	rm -rf $BUILD_DIR $NJS18X_DIST_X86_64
+	mkdir -p $DIST_DIR
+	npm install --prefix $BUILD_DIR newrelic@latest
+	mkdir -p $BUILD_DIR/node_modules/newrelic-lambda-wrapper
+	cp index.js $BUILD_DIR/node_modules/newrelic-lambda-wrapper
+	download_extension x86_64
+	zip -rq $NJS18X_DIST_X86_64 $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+	rm -rf $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+	echo "Build complete: ${NJS18X_DIST_X86_64}"
+}
+
+function publish-nodejs18x-arm64 {
+    if [ ! -f $NJS18X_DIST_ARM64 ]; then
+      echo "Package not found: ${NJS18X_DIST_ARM64}"
+      exit 1
+    fi
+
+    for region in "${REGIONS_ARM[@]}"; do
+      publish_layer $NJS18X_DIST_ARM64 $region nodejs18.x arm64
+    done
+}
+
+function publish-nodejs18x-x86 {
+    if [ ! -f $NJS18X_DIST_X86_64 ]; then
+      echo "Package not found: ${NJS18X_DIST_X86_64}"
+      exit 1
+    fi
+
+    for region in "${REGIONS_X86[@]}"; do
+      publish_layer $NJS18X_DIST_X86_64 $region nodejs18.x x86_64
+    done
+}
+
 case "$1" in
 "build-nodejs14x")
 	build-nodejs14x-arm64
@@ -130,6 +180,14 @@ case "$1" in
 	publish-nodejs16x-arm64
 	publish-nodejs16x-x86
 	;;
+"build-nodejs18x")
+	build-nodejs18x-arm64
+	build-nodejs18x-x86
+	;;
+"publish-nodejs18x")
+	publish-nodejs18x-arm64
+	publish-nodejs18x-x86
+	;;
 "nodejs14x")
 	$0 build-nodejs14x
 	$0 publish-nodejs14x
@@ -137,6 +195,10 @@ case "$1" in
 "nodejs16x")
 	$0 build-nodejs16x
 	$0 publish-nodejs16x
+	;;
+"nodejs18x")
+	$0 build-nodejs18x
+	$0 publish-nodejs18x
 	;;
 *)
 	usage


### PR DESCRIPTION
aws announced support for nodejs 18, to allow us the upgrade we need to have a nodejs 18 layer