### PR TITLE
feat: Added new ARM64-supporting regions

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -4,15 +4,26 @@ set -Eeuo pipefail
 
 # Regions that support arm64 architecture
 REGIONS_ARM=(
+  af-south-1
 	ap-northeast-1
+	ap-northeast-2
+	ap-northeast-3
 	ap-south-1
 	ap-southeast-1
 	ap-southeast-2
+	ap-southeast-3
+	ca-central-1
 	eu-central-1
+	eu-north-1
+	eu-south-1
 	eu-west-1
 	eu-west-2
+	eu-west-3
+	me-south-1
+	sa-east-1
 	us-east-1
 	us-east-2
+	us-west-1
 	us-west-2
 )
 

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -29,7 +29,6 @@ REGIONS_ARM=(
 
 REGIONS_X86=(
   af-south-1
-  ap-east-1
   ap-northeast-1
   ap-northeast-2
   ap-northeast-3


### PR DESCRIPTION
AWS introduced [new Graviton2-supporting regions](https://aws.amazon.com/about-aws/whats-new/2022/10/aws-lambda-functions-graviton2-12-regions/). This PR adds them to the ARM64 build/publish process. 

Closes NEWRELIC-5557

Signed-off-by: mrickard <maurice@mauricerickard.com>