### PR TITLE
Remove build for Python 3.6 layer.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,20 +30,6 @@ jobs:
           name: Publish layer
           command: make publish-nodejs16x-ci
 
-  publish-python36:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run:
-          name: Install publish dependencies
-          command: sudo pip install -U awscli
-      - run:
-          name: Publish layer
-          command: |
-            cd python
-            ./publish-layers.sh python3.6
-
   publish-python37:
     docker:
       - image: circleci/python:3.7
@@ -149,12 +135,6 @@ workflows:
             - codecov/upload:
                 file: ./nodejs/coverage/hidden-handler/lcov.info
                 flags: nodejs-16-hidden-handler
-      - publish-python36:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*_python/
       - publish-python37:
           filters:
             branches:

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -90,9 +90,6 @@ function layer_name_str() {
     "java11")
       rt_part="Java11"
       ;;
-    "python3.6")
-      rt_part="Python36"
-      ;;
     "python3.7")
       rt_part="Python37"
       ;;
@@ -131,9 +128,6 @@ function s3_prefix() {
       ;;
     "java11")
       name="java-11"
-      ;;
-    "python3.6")
-      name="nr-python3.6"
       ;;
     "python3.7")
       name="nr-python3.7"

--- a/python/publish-layers.sh
+++ b/python/publish-layers.sh
@@ -8,7 +8,6 @@ DIST_DIR=dist
 PY38_DIST_ARM64=$DIST_DIR/python38.arm64.zip
 PY39_DIST_ARM64=$DIST_DIR/python39.arm64.zip
 
-PY36_DIST_X86_64=$DIST_DIR/python36.x86_64.zip
 PY37_DIST_X86_64=$DIST_DIR/python37.x86_64.zip
 PY38_DIST_X86_64=$DIST_DIR/python38.x86_64.zip
 PY39_DIST_X86_64=$DIST_DIR/python39.x86_64.zip
@@ -16,31 +15,7 @@ PY39_DIST_X86_64=$DIST_DIR/python39.x86_64.zip
 source ../libBuild.sh
 
 function usage {
-    echo "./publish-layers.sh [python3.6|python3.7|python3.8|python3.9]"
-}
-
-function build-python36-x86 {
-    echo "Building New Relic layer for python3.6 (x86_64)"
-    rm -rf $BUILD_DIR $PY36_DIST_X86_64
-    mkdir -p $DIST_DIR
-    pip install --no-cache-dir -qU newrelic newrelic-lambda -t $BUILD_DIR/lib/python3.6/site-packages
-    cp newrelic_lambda_wrapper.py $BUILD_DIR/lib/python3.6/site-packages/newrelic_lambda_wrapper.py
-    find $BUILD_DIR -name '__pycache__' -exec rm -rf {} +
-    download_extension x86_64
-    zip -rq $PY36_DIST_X86_64 $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
-    rm -rf $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
-    echo "Build complete: ${PY36_DIST_X86_64}"
-}
-
-function publish-python36-x86 {
-    if [ ! -f $PY36_DIST_X86_64 ]; then
-        echo "Package not found: ${PY36_DIST_X86_64}"
-        exit 1
-    fi
-
-    for region in "${REGIONS_X86[@]}"; do
-      publish_layer $PY36_DIST_X86_64 $region python3.6 x86_64
-    done
+    echo "./publish-layers.sh [python3.7|python3.8|python3.9]"
 }
 
 function build-python37-x86 {
@@ -164,10 +139,6 @@ function publish-python39-x86 {
 }
 
 case "$1" in
-    "python3.6")
-        build-python36-x86
-        publish-python36-x86
-        ;;
     "python3.7")
         build-python37-x86
         publish-python37-x86


### PR DESCRIPTION
Python 3.6 is no longer supported by lambda nor the New Relic Python Agent. This PR removes Python 3.6 from the current lambda layers publishing process.