### PR TITLE
Updated CI images for Node jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   publish-nodejs14x:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14
     steps:
       - checkout
       - setup_remote_docker
@@ -19,7 +19,7 @@ jobs:
 
   publish-nodejs16x:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16
     steps:
       - checkout
       - setup_remote_docker
@@ -32,7 +32,7 @@ jobs:
 
   publish-nodejs18x:
     docker:
-      - image: circleci/node:18
+      - image: cimg/node:18
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
CircleCI has moved to next-generation images using the `cimg` namespace. As a result, there's no `circleci/node:18 image`. This commit updated all node job images. 

Closes NR-70339

Signed-off-by: mrickard <maurice@mauricerickard.com>