### PR TITLE
Update Python CI images for Python and Java jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
   publish-python37:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - run:
@@ -59,7 +59,7 @@ jobs:
 
   publish-python38:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - run:
@@ -73,7 +73,7 @@ jobs:
 
   publish-python39:
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     steps:
       - checkout
       - run:
@@ -87,7 +87,7 @@ jobs:
 
   publish-java8-al2:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - setup_remote_docker
@@ -97,7 +97,7 @@ jobs:
 
   publish-java11:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - setup_remote_docker
@@ -107,7 +107,7 @@ jobs:
 
   publish-extension:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Updating Python `circleci` images to `cimg` in conjunction with [Node image update](https://github.com/newrelic/newrelic-lambda-layers/pull/124). 