### PR TITLE
Add support for esm loading

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -13,11 +13,13 @@
     "clean": "rm ../dist/nodejs/NewRelicLayer.zip",
     "lint": "eslint ./*.js test",
     "lint:fix": "eslint --fix ./*.js test",
-    "test": "npm run lint && npm run testHandler && npm run testHiddenHandler",
+    "test": "npm run lint && npm run testHandler && npm run testHiddenHandler && npm run testEsmHandler",
     "testHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
+    "testEsmHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "testHiddenHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler",
+    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler && npm run ciTestEsmHandler",
     "ciTestHandler": "c8 -o ./coverage/handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
+    "ciTestEsmHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "ciTestHiddenHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456"
   },
   "repository": {

--- a/nodejs/test/fixtures/.hidden/.directory/.handler.js
+++ b/nodejs/test/fixtures/.hidden/.directory/.handler.js
@@ -3,6 +3,6 @@
 exports.handler = async (event, context) => {
     return {
         "statusCode": 200,
-        "body": "response body"
+        "body": `response body ${event.key}`
     };
 };

--- a/nodejs/test/fixtures/esm/handler.mjs
+++ b/nodejs/test/fixtures/esm/handler.mjs
@@ -1,0 +1,8 @@
+const handler = async(event, context) => {
+  return {
+    "statusCode": 200,
+    "body": `response body ${event.key}`
+  }
+}
+
+export {handler}

--- a/nodejs/test/fixtures/handler.js
+++ b/nodejs/test/fixtures/handler.js
@@ -4,6 +4,6 @@
 exports.handler = async(event, context) => {
   return {
     "statusCode": 200,
-    "body": "response body"
+    "body": `response body ${event.key}`
   }
 }


### PR DESCRIPTION
* add support for esm loading for nodejs18
* switch to async resolve of handler
* add test case to load esm
* extend test case to check that promise contains cached wrapped handler

Implements #126 

I have tested it by creating my own layers and loading it in v18, so fare it worked for me

@mrickard fyi