### PR TITLE
fix: WIP to fix ESM test handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Node 18 unit tests
-          command: cd nodejs && npm run ciTest
+          command: cd nodejs && npm run ciTest && run ciTestEsmHandler
       - run:
           name: Publish layer
           command: make publish-nodejs18x-ci

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -36,6 +36,8 @@ function getHandlerPath() {
 
 function handleRequireImportError(e, moduleToImport) {
   if (e.code === 'MODULE_NOT_FOUND') {
+    // console.log("errrrrrr", e)
+    // console.error(e)
     return new Error(`Unable to import module '${moduleToImport}'`)
   }
   return e

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "newrelic": "^9.0.3"
+        "newrelic": "^9.8.1"
       },
       "devDependencies": {
         "@newrelic/test-utilities": "^7.1.1",
@@ -448,6 +448,20 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@contrast/fn-inspect": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+      "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.16.0",
+        "node-gyp-build": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -472,9 +486,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.0.tgz",
-      "integrity": "sha512-wvKxal+40Xx11DXO2q5PfY3UiE25iwTb8SOz6A9IJII/V7d19x2ex0he+GJfVW0JZCaBjCPSjUB0yU9Ecm4WCw==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.7.tgz",
+      "integrity": "sha512-dRAWjRFN1Zy9mzPNLkFFIWT8T6C9euwluzCHZUKuhC+Bk3MayNPcpgDRyG+sg+n2sitEUySKxUynirVpu9ItKw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -483,61 +497,15 @@
         "node": "^8.13.0 || >=10.10.0"
       }
     },
-    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.2.tgz",
-      "integrity": "sha512-jCdyLIT/tdQ1zhrbTQnJNK5nbDf0GoBpy5jVNywBzzMDF+Vs6uEaHnfz46dMtDxkvwrF2hzk5Z67goliceH0sA==",
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
+      "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
         "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-      "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -923,9 +891,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg=="
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "node_modules/@tyriar/fibonacci-heap": {
       "version": "2.0.9",
@@ -1127,6 +1095,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -2957,6 +2933,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3212,18 +3196,19 @@
       "dev": true
     },
     "node_modules/newrelic": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.0.3.tgz",
-      "integrity": "sha512-PGmEWBm0VgScTagcOYJWl/wM3ny5VhbB6T+1wfeRvgSt8yMKBFXPNspp0RwKEzkU6Q9jf7aevjPzD8nNnDxCpg==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.8.1.tgz",
+      "integrity": "sha512-fwKnsEUv9ciBwYKAOZiC0AAeR9rqsTxJRiOQgD+0JooEaIE1UPAgG7iSZQujgfvB+Txk1s9gPCZ/oK8nsyBzlA==",
       "dependencies": {
-        "@grpc/grpc-js": "^1.5.5",
-        "@grpc/proto-loader": "^0.6.13",
+        "@grpc/grpc-js": "^1.7.3",
+        "@grpc/proto-loader": "^0.7.3",
         "@newrelic/aws-sdk": "^5.0.0",
         "@newrelic/koa": "^7.0.0",
         "@newrelic/superagent": "^6.0.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
+        "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
         "readable-stream": "^3.6.0",
         "semver": "^5.3.0",
@@ -3237,6 +3222,7 @@
         "npm": ">=6.0.0"
       },
       "optionalDependencies": {
+        "@contrast/fn-inspect": "^3.3.0",
         "@newrelic/native-metrics": "^9.0.0"
       }
     },
@@ -3265,6 +3251,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-preload": {
@@ -3804,9 +3801,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.0.tgz",
+      "integrity": "sha512-hYCqTDuII4iJ4stZqiuGCSU8xxWl5JeXYpwARGtn/tWcKCAro6h3WQz+xpsNbXW0UYqpmTQFEyFWO0G0Kjt64g==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3819,14 +3816,17 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/proxyquire": {
       "version": "2.1.3",
@@ -7044,6 +7044,16 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
+    "@contrast/fn-inspect": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+      "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.16.0",
+        "node-gyp-build": "^4.4.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -7062,63 +7072,23 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.0.tgz",
-      "integrity": "sha512-wvKxal+40Xx11DXO2q5PfY3UiE25iwTb8SOz6A9IJII/V7d19x2ex0he+GJfVW0JZCaBjCPSjUB0yU9Ecm4WCw==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.7.tgz",
+      "integrity": "sha512-dRAWjRFN1Zy9mzPNLkFFIWT8T6C9euwluzCHZUKuhC+Bk3MayNPcpgDRyG+sg+n2sitEUySKxUynirVpu9ItKw==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
-      },
-      "dependencies": {
-        "@grpc/proto-loader": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.2.tgz",
-          "integrity": "sha512-jCdyLIT/tdQ1zhrbTQnJNK5nbDf0GoBpy5jVNywBzzMDF+Vs6uEaHnfz46dMtDxkvwrF2hzk5Z67goliceH0sA==",
-          "requires": {
-            "@types/long": "^4.0.1",
-            "lodash.camelcase": "^4.3.0",
-            "long": "^4.0.0",
-            "protobufjs": "^7.0.0",
-            "yargs": "^16.2.0"
-          }
-        },
-        "protobufjs": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-          "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          },
-          "dependencies": {
-            "long": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-              "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
-            }
-          }
-        }
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
+      "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
+        "protobufjs": "^7.0.0",
         "yargs": "^16.2.0"
       }
     },
@@ -7415,9 +7385,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
-      "version": "18.7.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg=="
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "@tyriar/fibonacci-heap": {
       "version": "2.0.9",
@@ -7565,6 +7535,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -8910,6 +8885,14 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9116,12 +9099,13 @@
       "dev": true
     },
     "newrelic": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.0.3.tgz",
-      "integrity": "sha512-PGmEWBm0VgScTagcOYJWl/wM3ny5VhbB6T+1wfeRvgSt8yMKBFXPNspp0RwKEzkU6Q9jf7aevjPzD8nNnDxCpg==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.8.1.tgz",
+      "integrity": "sha512-fwKnsEUv9ciBwYKAOZiC0AAeR9rqsTxJRiOQgD+0JooEaIE1UPAgG7iSZQujgfvB+Txk1s9gPCZ/oK8nsyBzlA==",
       "requires": {
-        "@grpc/grpc-js": "^1.5.5",
-        "@grpc/proto-loader": "^0.6.13",
+        "@contrast/fn-inspect": "^3.3.0",
+        "@grpc/grpc-js": "^1.7.3",
+        "@grpc/proto-loader": "^0.7.3",
         "@newrelic/aws-sdk": "^5.0.0",
         "@newrelic/koa": "^7.0.0",
         "@newrelic/native-metrics": "^9.0.0",
@@ -9129,6 +9113,7 @@
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
+        "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
         "readable-stream": "^3.6.0",
         "semver": "^5.3.0",
@@ -9157,6 +9142,12 @@
           }
         }
       }
+    },
+    "node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "optional": true
     },
     "node-preload": {
       "version": "0.2.1",
@@ -9567,9 +9558,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.0.tgz",
+      "integrity": "sha512-hYCqTDuII4iJ4stZqiuGCSU8xxWl5JeXYpwARGtn/tWcKCAro6h3WQz+xpsNbXW0UYqpmTQFEyFWO0G0Kjt64g==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9581,9 +9572,15 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+        }
       }
     },
     "proxyquire": {

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -17,7 +17,8 @@
         "eslint": "^8.23.1",
         "eslint-plugin-import": "^2.26.0",
         "proxyquire": "^2.1.3",
-        "tap": "^16.3.0"
+        "tap": "^16.3.0",
+        "testdouble": "^3.16.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2678,6 +2679,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -2692,6 +2702,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -3849,6 +3868,20 @@
         }
       ]
     },
+    "node_modules/quibble": {
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
+      "integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -4205,6 +4238,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-ansi": {
@@ -6282,10 +6328,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/testdouble": {
+      "version": "3.16.8",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.8.tgz",
+      "integrity": "sha512-jOKYRJ9mfgDxwuUOj84sl9DWiP1+KpHcgnhjlSHC8h1ZxJT3KD1FAAFVqnqmmyrzc/+0DRbI/U5xo1/K3PLi8w==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.14",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -8638,6 +8705,12 @@
       "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -8647,6 +8720,12 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -9530,6 +9609,16 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quibble": {
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
+      "integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -9792,6 +9881,16 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
+      }
+    },
+    "stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -11150,10 +11249,28 @@
         "minimatch": "^3.0.4"
       }
     },
+    "testdouble": {
+      "version": "3.16.8",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.8.tgz",
+      "integrity": "sha512-jOKYRJ9mfgDxwuUOj84sl9DWiP1+KpHcgnhjlSHC8h1ZxJT3KD1FAAFVqnqmmyrzc/+0DRbI/U5xo1/K3PLi8w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.14",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
     "to-fast-properties": {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -15,12 +15,12 @@
     "lint:fix": "eslint --fix ./*.js test",
     "test": "npm run lint && npm run testHandler && npm run testHiddenHandler",
     "testHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "testEsmHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble",
+    "testEsmHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble --node-arg=--experimental-loader=newrelic/esm-loader.mjs",
     "testHiddenHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler",
+    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler && npm run ciTestEsmHandler",
     "ciTestHandler": "c8 -o ./coverage/handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "ciTestEsmHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble",
-    "ciTestHiddenHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456"
+    "ciTestEsmHandler": "c8 -o ./coverage/handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble --node-arg=--experimental-loader=newrelic/esm-loader.mjs",
+    "ciTestHiddenHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456 "
   },
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/newrelic/newrelic-lambda-layers#readme",
   "dependencies": {
-    "newrelic": "^9.0.3"
+    "newrelic": "^9.8.1"
   },
   "keywords": [
     "lambda",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -15,11 +15,11 @@
     "lint:fix": "eslint --fix ./*.js test",
     "test": "npm run lint && npm run testHandler && npm run testHiddenHandler && npm run testEsmHandler",
     "testHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "testEsmHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
+    "testEsmHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble",
     "testHiddenHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler && npm run ciTestEsmHandler",
     "ciTestHandler": "c8 -o ./coverage/handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "ciTestEsmHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456",
+    "ciTestEsmHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble",
     "ciTestHiddenHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456"
   },
   "repository": {
@@ -53,6 +53,7 @@
     "eslint": "^8.23.1",
     "eslint-plugin-import": "^2.26.0",
     "proxyquire": "^2.1.3",
-    "tap": "^16.3.0"
+    "tap": "^16.3.0",
+    "testdouble": "^3.16.8"
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -13,11 +13,11 @@
     "clean": "rm ../dist/nodejs/NewRelicLayer.zip",
     "lint": "eslint ./*.js test",
     "lint:fix": "eslint --fix ./*.js test",
-    "test": "npm run lint && npm run testHandler && npm run testHiddenHandler && npm run testEsmHandler",
+    "test": "npm run lint && npm run testHandler && npm run testHiddenHandler",
     "testHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "testEsmHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble",
     "testHiddenHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler && npm run ciTestEsmHandler",
+    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler",
     "ciTestHandler": "c8 -o ./coverage/handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "ciTestEsmHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.mjs)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456 --node-arg=--experimental-loader=testdouble",
     "ciTestHiddenHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler  --test-env=NEW_RELIC_LICENSE_KEY=0123456"

--- a/nodejs/test/layer.tap.mjs
+++ b/nodejs/test/layer.tap.mjs
@@ -11,17 +11,21 @@ import * as utils from '@newrelic/test-utilities'
 
 tap.test('Layer tests', (t) => {
   t.autoend()
-  let handler, getHandlerPath, helper
+  let handler, getHandlerPath, helper, wrapper
 
   t.beforeEach(async () => {
     helper = utils.TestAgent.makeInstrumented()
-    const newrelic = helper.getAgentApi()
-    ;({ handler, getHandlerPath } = await import('../index.js'))
-    await td.replaceEsm('../index.js', { 'handler': handler, 'getHandlerPath': getHandlerPath }, newrelic)
+    // const newrelic = helper.getAgentApi();
+    const newrelic = helper.getAgentApi();
+    // await td.replace('newrelic', newrelic);
+    await td.replaceEsm('newrelic', newrelic);
+    await import('newrelic')
+    console.log("NEW RELIC", newrelic);
+    ({ handler, getHandlerPath } = await import('../index.js'))
   })
   t.afterEach(() => {
-    helper.unload()
     td.reset()
+    helper.unload()
   })
   t.test('New Relic handler wraps customer handler', (t) => {
     const p = getHandlerPath()

--- a/nodejs/test/layer.tap.mjs
+++ b/nodejs/test/layer.tap.mjs
@@ -5,23 +5,23 @@
 
 'use strict'
 
-const tap = require('tap')
-const proxyquire = require('proxyquire')
-const utils = require('@newrelic/test-utilities')
+import tap from 'tap'
+import * as td from 'testdouble'
+import * as utils from '@newrelic/test-utilities'
 
 tap.test('Layer tests', (t) => {
   t.autoend()
   let handler, getHandlerPath, helper
 
-  t.beforeEach(() => {
+  t.beforeEach(async () => {
     helper = utils.TestAgent.makeInstrumented()
     const newrelic = helper.getAgentApi()
-        ;({ handler, getHandlerPath } = proxyquire('../index', {
-      newrelic
-    }))
+    ;({ handler, getHandlerPath } = await import('../index.js'))
+    await td.replaceEsm('../index.js', { 'handler': handler, 'getHandlerPath': getHandlerPath }, newrelic)
   })
   t.afterEach(() => {
     helper.unload()
+    td.reset()
   })
   t.test('New Relic handler wraps customer handler', (t) => {
     const p = getHandlerPath()

--- a/nodejs/test/layer.tap.mjs
+++ b/nodejs/test/layer.tap.mjs
@@ -11,17 +11,16 @@ import * as utils from '@newrelic/test-utilities'
 
 tap.test('Layer tests', (t) => {
   t.autoend()
-  let handler, getHandlerPath, helper, wrapper
+  let handler, getHandlerPath, helper, fakeAgent
 
   t.beforeEach(async () => {
     helper = utils.TestAgent.makeInstrumented()
-    // const newrelic = helper.getAgentApi();
-    const newrelic = helper.getAgentApi();
-    // await td.replace('newrelic', newrelic);
-    await td.replaceEsm('newrelic', newrelic);
-    await import('newrelic')
-    console.log("NEW RELIC", newrelic);
-    ({ handler, getHandlerPath } = await import('../index.js'))
+    fakeAgent = helper.getAgentApi()
+    // await td.replace('newrelic', fakeAgent); // doesn't replace nr
+    const replaced = await (await td.replaceEsm('newrelic', {},  fakeAgent));  // Looks weird and wrong
+        // How to apply the replaced newrelic to this imported file under test?
+        // It's still referencing the real, unmocked NR agent.
+        ({handler, getHandlerPath} = await import('../index.js'));
   })
   t.afterEach(() => {
     td.reset()


### PR DESCRIPTION
ESM tests are failing for Node 14 and 16, which...maybe isn't a problem, because layer-based instrumentation isn't available for those versions. Node 18 passes tests...but when I dig into the code that's failing in 14 and 16, it is *also* throwing errors in Node 18 ESM tests, because proxyquire's `require` method isn't supported in an ESM context. (Oddly, those errors are just swallowed, which is how Node 18 is passing.)

This is an attempt to guarantee that the agent is wrapping ESM for Node 18, but I'm not yet able to get testdouble to inject the agent helper in the wrapper file. 

Signed-off-by: mrickard <maurice@mauricerickard.com>