### PR TITLE
fix(NEWRELIC-7409): allow ESM modules to be defined via package.json

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newrelic-lambda-layers",
-  "version": "9.0.3",
+  "version": "9.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newrelic-lambda-layers",
-      "version": "9.0.3",
+      "version": "9.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "newrelic": "^9.0.3"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -13,13 +13,15 @@
     "clean": "rm ../dist/nodejs/NewRelicLayer.zip",
     "lint": "eslint ./*.js test",
     "lint:fix": "eslint --fix ./*.js test",
-    "test": "npm run lint && npm run testHandler && npm run testHiddenHandler && npm run testEsmHandler",
+    "test": "npm run lint && npm run testHandler && npm run testHiddenHandler && npm run testEsmHandler && npm run testEsmPackageHandler",
     "testHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "testEsmHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
+    "testEsmPackageHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esmPkg/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "testHiddenHandler": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
-    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler && npm run ciTestEsmHandler",
+    "ciTest": "npm install && npm run lint && npm run ciTestHandler && npm run ciTestHiddenHandler && npm run ciTestEsmHandler && npm run ciTestEsmPkgHandler",
     "ciTestHandler": "c8 -o ./coverage/handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "ciTestEsmHandler": "c8 -o ./coverage/esm-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esm/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
+    "ciTestEsmPkgHandler": "c8 -o ./coverage/esm-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/esmPkg/handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456",
     "ciTestHiddenHandler": "c8 -o ./coverage/hidden-handler tap --test-regex='(\\/|^test\\/.*\\.tap\\.js)$' --timeout=180 --no-coverage --reporter classic --test-env=NEW_RELIC_LAMBDA_HANDLER=test/fixtures/.hidden/.directory/.handler.handler --test-env=NEW_RELIC_LICENSE_KEY=0123456"
   },
   "repository": {

--- a/nodejs/test/fixtures/esmPkg/.eslintrc.json
+++ b/nodejs/test/fixtures/esmPkg/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/nodejs/test/fixtures/esmPkg/handler.js
+++ b/nodejs/test/fixtures/esmPkg/handler.js
@@ -1,0 +1,8 @@
+const handler = async(event) => {
+  return {
+    "statusCode": 200,
+    "body": `response body ${event.key}`
+  }
+}
+
+export {handler}

--- a/nodejs/test/fixtures/esmPkg/package.json
+++ b/nodejs/test/fixtures/esmPkg/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}


### PR DESCRIPTION
This checks to see if the file was found but attempted require of a module, so we attempt an import instead.