### PR TITLE
chore: added new regions

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -33,16 +33,21 @@ REGIONS_X86=(
   ap-northeast-2
   ap-northeast-3
   ap-south-1
+  ap-south-2
   ap-southeast-1
   ap-southeast-2
   ap-southeast-3
+  ap-southeast-4
   ca-central-1
   eu-central-1
+  eu-central-2
   eu-north-1
   eu-south-1
+  eu-south-2
   eu-west-1
   eu-west-2
   eu-west-3
+  me-central-1
   me-south-1
   sa-east-1
   us-east-1


### PR DESCRIPTION
New x86-only regions have been added: 
ap-south-2
ap-southeast-4
eu-south-2
eu-central-2
me-central-1

