### PR TITLE
fix: update circleci configuration to install deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Node 14 unit tests
-          command: cd nodejs && npm run test
+          command: cd nodejs && npm install && npm run test
       - run:
           name: Publish layer
           command: make publish-nodejs14x-ci
@@ -25,7 +25,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Node 16 unit tests
-          command: cd nodejs && npm run test
+          command: cd nodejs && npm install && npm run test
       - run:
           name: Publish layer
           command: make publish-nodejs16x-ci
@@ -38,7 +38,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Node 18 unit tests
-          command: cd nodejs && npm run test
+          command: cd nodejs && npm install && npm run test
       - run:
           name: Publish layer
           command: make publish-nodejs18x-ci


### PR DESCRIPTION
In #156, we broke the publish job by removing `ciTest` npm script, which internally was calling `npm install` inline to install the dev deps. This updates the circleci job to handle running `npm install` itself