### PR TITLE
Update config.yml to remove sudo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - checkout
       - run:
           name: Install publish dependencies
-          command: sudo pip install -U awscli
+          command: pip install -U awscli
       - run:
           name: Publish layer
           command: |
@@ -64,7 +64,7 @@ jobs:
       - checkout
       - run:
           name: Install publish dependencies
-          command: sudo pip install -U awscli
+          command: pip install -U awscli
       - run:
           name: Publish layer
           command: |
@@ -78,7 +78,7 @@ jobs:
       - checkout
       - run:
           name: Install publish dependencies
-          command: sudo pip install -U awscli
+          command: pip install -U awscli
       - run:
           name: Publish layer
           command: |
@@ -92,7 +92,7 @@ jobs:
       - checkout
       - run:
           name: Install publish dependencies
-          command: sudo pip install -U awscli
+          command: pip install -U awscli
       - run:
           name: Publish layer
           command: |
@@ -126,7 +126,7 @@ jobs:
       - checkout
       - run:
           name: Install publish dependencies
-          command: sudo pip install -U awscli
+          command: pip install -U awscli
       - run:
           name: Publish layer
           command: |


### PR DESCRIPTION
sudo in docker containers is unsafe. The superuser in circle CI does not seem to have pip access.

Example: https://app.circleci.com/pipelines/github/newrelic/newrelic-lambda-layers/631/workflows/49e348cb-3da1-4773-97c6-7af9d174a5c9/jobs/888

```
#!/bin/bash -eo pipefail
sudo pip install -U awscli
sudo: pip: command not found

Exited with code exit status 1
```