### PR TITLE
Catch unhandled exception and log it

### DIFF
--- a/python/newrelic_lambda_wrapper.py
+++ b/python/newrelic_lambda_wrapper.py
@@ -83,6 +83,7 @@ def handler(event, context):
     context.iopipe = IOpipeNoOp()
     try:
         return wrapped_handler(event, context)
-    except err
-        print("Caught exception:", err)
+    except Exception as err:
+        import traceback
+        traceback.print_exc()
         raise 

--- a/python/newrelic_lambda_wrapper.py
+++ b/python/newrelic_lambda_wrapper.py
@@ -81,4 +81,8 @@ wrapped_handler = get_handler()
 @lambda_handler()
 def handler(event, context):
     context.iopipe = IOpipeNoOp()
-    return wrapped_handler(event, context)
+    try:
+        return wrapped_handler(event, context)
+    except err
+        print("Caught exception:", err)
+        raise 


### PR DESCRIPTION
If the customer's code raises an exception, the traceback never reaches new relic logs. If the customer does not have Cloudwatch logs enabled, they won't be able to see the error making the issue difficult to discover and debug. This PR add a try around the `wrapped_handler` It catches all exceptions, prints the exception and raises the exception again