### PR TITLE
Update Python 3.10 & 3.11 build images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
 
   publish-python310:
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:
@@ -101,7 +101,7 @@ jobs:
 
   publish-python311:
     docker:
-      - image: circleci/python:3.11
+      - image: cimg/python:3.11
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR updates the Python 3.10 and 3.11 images from `circleci` to `cimg`.