### PR TITLE
Add Java 17 support to the NR lambda layers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,16 @@ jobs:
           name: Publish layer
           command: make publish-java11-ci
 
+  publish-java17:
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Publish layer
+          command: make publish-java17-ci
+
   publish-extension:
     docker:
       - image: cimg/python:3.8
@@ -188,6 +198,12 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*_python/
       - publish-java11:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*_java/
+      - publish-java17:
           filters:
             branches:
               ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,25 @@ publish-java11-local: build-java11
 		-v "${HOME}/.aws:/home/newrelic-lambda-layers/.aws" \
 		newrelic-lambda-layers-java11
 
+build-java17:
+	docker build \
+		--no-cache \
+		-t newrelic-lambda-layers-java17 \
+		-f ./dockerfiles/Dockerfile.java17 \
+		.
+
+publish-java17-ci: build-java17
+	docker run \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		newrelic-lambda-layers-java17
+
+publish-java17-local: build-java17
+	docker run \
+		-e AWS_PROFILE \
+		-v "${HOME}/.aws:/home/newrelic-lambda-layers/.aws" \
+		newrelic-lambda-layers-java17
+
 build-nodejs16x:
 	docker build \
 		--no-cache \

--- a/dockerfiles/Dockerfile.java17
+++ b/dockerfiles/Dockerfile.java17
@@ -1,0 +1,29 @@
+FROM openjdk:17 as builder
+
+RUN apt-get update \
+    && apt-get install -y curl unzip zip
+
+RUN useradd -m newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+
+COPY --chown=newrelic-lambda-layers libBuild.sh .
+COPY --chown=newrelic-lambda-layers java java/
+
+WORKDIR java
+RUN ./publish-layers.sh build-java17
+
+FROM python:3.8
+
+RUN useradd -m newrelic-lambda-layers
+USER newrelic-lambda-layers
+WORKDIR /home/newrelic-lambda-layers
+RUN pip3 install -U awscli --user
+ENV PATH /home/newrelic-lambda-layers/.local/bin/:$PATH
+
+COPY libBuild.sh .
+COPY java java/
+COPY --from=builder /home/newrelic-lambda-layers/java/dist java/dist
+
+WORKDIR java
+CMD ./publish-layers.sh publish-java17

--- a/dockerfiles/Dockerfile.java17
+++ b/dockerfiles/Dockerfile.java17
@@ -1,4 +1,4 @@
-FROM openjdk:17 as builder
+FROM eclipse-temurin:17 as builder
 
 RUN apt-get update \
     && apt-get install -y curl unzip zip

--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,3 +1,7 @@
 .gradle
 .idea
 build
+bin
+extensions
+gradlew.bat
+preview-extensions*

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -38,12 +38,27 @@ task packageLayer(type: Zip) {
     with extensions
 }
 
-ext.javaVersion = hasProperty('javaVersion') && project.getProperty('javaVersion') == 11 ?
-        JavaVersion.VERSION_11 : JavaVersion.VERSION_1_8
+if (hasProperty('javaVersion')) {
+    switch(project.getProperty('javaVersion')) {
+        case 11:
+            ext.javaVersion = JavaVersion.VERSION_11
+            break
+        case 17:
+            ext.javaVersion = JavaVersion.VERSION_17
+            break
+    }
+} else {
+    ext.javaVersion = JavaVersion.VERSION_1_8
+}
+logger.lifecycle("Using javaVersion: ${ext.javaVersion}")
 
 java {
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
+}
+
+test {
+    jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED', '--add-opens', 'java.base/java.util=ALL-UNNAMED']
 }
 
 packageLayer.dependsOn build

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/publish-layers.sh
+++ b/java/publish-layers.sh
@@ -159,6 +159,7 @@ case "$1" in
 "build-java17")
 	build-java17-arm64
 	build-java17-x86
+        ;;
 "publish-java17")
 	publish-java17-arm64
 	publish-java17-x86

--- a/java/publish-layers.sh
+++ b/java/publish-layers.sh
@@ -156,6 +156,9 @@ case "$1" in
 	publish-java11-arm64
 	publish-java11-x86
 	;;
+"build-java17")
+	build-java17-arm64
+	build-java17-x86
 "publish-java17")
 	publish-java17-arm64
 	publish-java17-x86

--- a/java/publish-layers.sh
+++ b/java/publish-layers.sh
@@ -10,11 +10,13 @@ JAVA8_DIST_ARM64=$DIST_DIR/java8.arm64.zip
 JAVA8_DIST_X86_64=$DIST_DIR/java8.x86_64.zip
 JAVA11_DIST_ARM64=$DIST_DIR/java11.arm64.zip
 JAVA11_DIST_X86_64=$DIST_DIR/java11.x86_64.zip
+JAVA17_DIST_ARM64=$DIST_DIR/java17.arm64.zip
+JAVA17_DIST_X86_64=$DIST_DIR/java17.x86_64.zip
 
 source ../libBuild.sh
 
 function usage {
-	  echo "./publish-layers.sh [java8al2, java11]"
+	  echo "./publish-layers.sh [java8al2, java11, java17]"
 }
 
 function build-arm() {
@@ -107,6 +109,36 @@ function publish-java11-x86 {
     done
 }
 
+function build-java17-arm64 {
+    build-arm "java17 (arm64)" 17 $JAVA17_DIST_ARM64
+}
+
+function build-java17-x86 {
+    build-x86 "java17 (x86_64)" 17 $JAVA17_DIST_X86_64
+}
+
+function publish-java17-arm64 {
+    if [ ! -f $JAVA17_DIST_ARM64 ]; then
+      echo "Package not found"
+      exit 1
+    fi
+
+    for region in "${REGIONS_ARM[@]}"; do
+      publish_layer $JAVA17_DIST_ARM64 $region java17 arm64
+    done
+}
+
+function publish-java17-x86 {
+    if [ ! -f $JAVA17_DIST_X86_64 ]; then
+      echo "Package not found"
+      exit 1
+    fi
+
+    for region in "${REGIONS_X86[@]}"; do
+      publish_layer $JAVA17_DIST_X86_64 $region java17 x86_64
+    done
+}
+
 case "$1" in
 "build-java8al2")
 	build-java8al2-arm64
@@ -124,6 +156,10 @@ case "$1" in
 	publish-java11-arm64
 	publish-java11-x86
 	;;
+"publish-java17")
+	publish-java17-arm64
+	publish-java17-x86
+	;;
 "java8al2")
 	$0 build-java8al2
 	$0 publish-java8al2
@@ -131,6 +167,10 @@ case "$1" in
 "java11")
 	$0 build-java11
 	$0 publish-java11
+	;;
+"java17")
+	$0 build-java17
+	$0 publish-java17
 	;;
 *)
 	usage

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -95,6 +95,9 @@ function layer_name_str() {
     "java11")
       rt_part="Java11"
       ;;
+    "java17")
+      rt_part="Java17"
+      ;;
     "python3.7")
       rt_part="Python37"
       ;;


### PR DESCRIPTION
Thanks to @gliptak for the original PR that added Java 17 support.

- Bumped version of gradle to v7.6.2
- Added `--add-opens` JVM args to gradle `test` lifecycle to get around J17 restrictions on reflecting on core Java classes
- Displays detected Java version during build time
