### PR TITLE
fix: Revert extension to 2.3.9 to unblock publishing

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -60,7 +60,7 @@ EXTENSION_DIST_DIR=extensions
 EXTENSION_DIST_ZIP=extension.zip
 EXTENSION_DIST_PREVIEW_FILE=preview-extensions-ggqizro707
 
-EXTENSION_VERSION=2.3.10
+EXTENSION_VERSION=2.3.9
 
 function list_all_regions {
     aws ec2 describe-regions \


### PR DESCRIPTION
Layer publishing CI failed on December 12, with failures pointing to a missing or malformed extension file. See https://app.circleci.com/pipelines/github/newrelic/newrelic-lambda-layers/752/workflows/0d5eb160-1556-4ca8-a14f-efe45b792320/jobs/1017

Node layer tests are unlikely to complete, as they're skipped when there are no Node changes.