### PR TITLE
fix: Revert extension to 2.3.9 

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -60,7 +60,7 @@ EXTENSION_DIST_DIR=extensions
 EXTENSION_DIST_ZIP=extension.zip
 EXTENSION_DIST_PREVIEW_FILE=preview-extensions-ggqizro707
 
-EXTENSION_VERSION=2.3.11
+EXTENSION_VERSION=2.3.9
 
 function list_all_regions {
     aws ec2 describe-regions \


### PR DESCRIPTION
Customers have reported several issues with yesterday's release of the Lambda Extension. This PR reverts to the previously released 2.3.9 while the Extension owners investigate. 

See https://github.com/newrelic/serverless-newrelic-lambda-layers/issues/404 (This issue was reported there because the plugin for Serverless is designed to apply the most recent layer version for a given runtime, so all users of the plugin are blocked from new deployments until a new layer is published.)
