### PR TITLE
fix(Java): Log exception stack trace

### DIFF
--- a/java/src/main/java/com/newrelic/java/JavaClassLoader.java
+++ b/java/src/main/java/com/newrelic/java/JavaClassLoader.java
@@ -77,7 +77,7 @@ public class JavaClassLoader implements RequestHandler<Object, Object> {
         try {
             return executor.handle(mappingInputToHandlerType(inputParam, inputType), contextParam);
         } catch (Throwable e) {
-            throw new RuntimeException("Error occurred while invoking handler method: " + e);
+            throw new RuntimeException("Error occurred while invoking handler method: " + e, e);
         }
     }
 


### PR DESCRIPTION
When the following exception was caught, it did not log the stack trace, which made it difficult to figure out what happened.