### PR TITLE
chore: Added bash script and Docker file for auto creation of ECRs for lambda layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:latest as layer-copy
+
+ARG layer_zip
+ARG file_without_dist
+
+RUN apk update && apk add --no-cache curl unzip
+
+WORKDIR /
+
+COPY ${layer_zip} .
+
+RUN unzip ${file_without_dist} -d ./opt
+RUN rm ${file_without_dist}

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -276,7 +276,7 @@ function publish_docker_ecr {
     fi
 
     # public ecr repository name 
-    # for testting 
+    # for testing 
     #repository="q6k3q1g1"
     # for prod 
     repository="x6n7b2o2"

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 
 # Regions that support arm64 architecture
 REGIONS_ARM=(
-  af-south-1
+	af-south-1
 	ap-northeast-1
 	ap-northeast-2
 	ap-northeast-3
@@ -239,4 +239,71 @@ function publish_layer {
       --principal "*" \
       --region "$region"
     echo "Public permissions set for ${runtime_name} layer version ${layer_version} in region ${region}"
+
+    # Creating layer as a docker image and publishing it in ECR 
+    if [ "$region" = "us-east-1" ]; then
+        publish_docker_ecr $layer_archive $region $runtime_name $arch $layer_name $layer_version
+    fi
+
+
+}
+
+function publish_docker_ecr {
+    layer_archive=$1
+    region=$2
+    runtime_name=$3
+    arch=$4
+    layer_name=$5
+    layer_version=$6
+
+    if [[ ${arch} =~ 'arm64' ]];
+    then arch_flag="-arm64"
+    else arch_flag=""
+    fi
+
+    version_flag=$(echo "$runtime_name" | sed 's/[^0-9]//g')
+    language_flag=$(echo "$runtime_name" | sed 's/[0-9].*//')
+
+    echo "runtime_name ${region} ${runtime_name} ${layer_name} ${language_flag} ${version_flag} ${arch}"
+
+    # Remove 'dist/' prefix
+    if [[ $layer_archive == dist/* ]]; then
+      file_without_dist="${layer_archive#dist/}"
+      echo "File without 'dist/': $file_without_dist"
+    else
+      file_without_dist=$layer_archive
+      echo "File does not start with 'dist/': $file_without_dist"
+    fi
+
+    # public ecr repository name 
+    # for testting 
+    repository="q6k3q1g1"
+    # for prod 
+    #repository="x6n7b2o2"
+
+    # copy dockerfile
+    cp ../Dockerfile .
+
+    echo "Running : aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/${repository}"
+    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/${repository}
+
+    echo "docker build -t layer-nr-image-${language_flag}-${version_flag}${arch_flag}:latest \
+    --build-arg layer_zip=${layer_archive} \
+    --build-arg file_without_dist=${file_without_dist} \
+    ."
+
+    docker build -t layer-nr-image-${language_flag}-${version_flag}${arch_flag}:latest \
+    --build-arg layer_zip=${layer_archive} \
+    --build-arg file_without_dist=${file_without_dist} \
+    .
+   
+    echo "docker tag layer-nr-image-${language_flag}-${version_flag}${arch_flag}:latest public.ecr.aws/${repository}/newrelic-lambda-layers-${language_flag}:${version_flag}${arch_flag}"
+    docker tag layer-nr-image-${language_flag}-${version_flag}${arch_flag}:latest public.ecr.aws/${repository}/newrelic-lambda-layers-${language_flag}:${version_flag}${arch_flag}
+    echo "docker push public.ecr.aws/${repository}/newrelic-lambda-layers-${language_flag}:${version_flag}${arch_flag}"
+    docker push public.ecr.aws/${repository}/newrelic-lambda-layers-${language_flag}:${version_flag}${arch_flag}
+
+    # delete dockerfile
+    rm -rf Dockerfile
+
+
 }

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -277,9 +277,9 @@ function publish_docker_ecr {
 
     # public ecr repository name 
     # for testting 
-    repository="q6k3q1g1"
+    #repository="q6k3q1g1"
     # for prod 
-    #repository="x6n7b2o2"
+    repository="x6n7b2o2"
 
     # copy dockerfile
     cp ../Dockerfile .


### PR DESCRIPTION
**Ticket**: https://new-relic.atlassian.net/browse/NR-219713

Currently, our Layers scripts is for publish [layers](https://layers.newrelic-external.com/#/get-layers/get) in all regions.

And, we are also created docker lambda [layers in ECRs](https://gallery.ecr.aws/newrelic-lambda-layers-for-docker) for Python, Node and Java. So, We need to publish ECRs if any new versions are released for these languages. 
In this PR :- I've written a bash script code for publishing ECRs automatically if any new releases is happen.  

**How to test**

1. Make sure you are authenticated with AWS test account for testing.
2. I've already created a ECR [repository](https://gallery.ecr.aws/q6k3q1g1?page=1) for testing.
3. Don't forgot to use testing repository for testing purpose.
    ```
    For testing 
    repository="q6k3q1g1"
    For prod 
    #repository="x6n7b2o2" ```
    
4. If you are using any new AWS account for testing then don't forgot to create language based public ECRs in AWS.  

Note*: ECRs script will work only for us-east-1 region. Because AWS ECRs are global so i'm just running this script for one region i.e. us-east-1