### PR TITLE
feat: Add initial dotnet Lambda layer support

### DIFF
--- a/.github/workflows/publish-dotnet.yml
+++ b/.github/workflows/publish-dotnet.yml
@@ -1,0 +1,29 @@
+name: Publish Dotnet Layers
+
+on:
+  push:
+    tags:
+      - v**_dotnet
+
+jobs:
+  publish-dotnet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Tag
+        id: dotnet-check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+(\.[0-9]+)*_dotnet ]]; then
+              AGENT_VERSION=$( echo ${{ github.event.ref }} | grep -Eo "[0-9]+(\.[0-9]+)*" )
+              echo "version=$AGENT_VERSION" >> $GITHUB_OUTPUT
+              echo "match=true" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@v4
+      - name: Publish Dotnet Layer
+        if: steps.dotnet-check-tag.outputs.match == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AGENT_VERSION: ${{ steps.dotnet-check-tag.outputs.version }}
+        run: |
+          cd dotnet
+          ./publish-layers.sh

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ cd ..
 ```
 
 ```
+cd dotnet
+./publish-layers.sh
+cd ..
+```
+
+```
 cd extension
 ./publish-layer.sh
 cd ..
@@ -78,10 +84,15 @@ These steps will help you configure the layers correctly:
   * Java:
     * RequestHandler implementation: `com.newrelic.java.HandlerWrapper::handleRequest`
     * RequestStreamHandlerWrapper implementation: `com.newrelic.java.HandlerWrapper::handleStreamsRequest`
+  * .NET: This step is not required.
 4. Add these environment variables to your Lambda console:
   * NEW_RELIC_ACCOUNT_ID: Your New Relic account ID
   * NEW_RELIC_LAMBDA_HANDLER: Path to your initial handler.
   * NEW_RELIC_USE_ESM: For Node.js handlers using ES Modules, set to `true`.
+  * CORECLR_ENABLE_PROFILING (.NET only): 1
+  * CORECLR_PROFILER (.NET only): {36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+  * CORECLR_NEWRELIC_HOME (.NET only): /opt/lib/newrelic-dotnet-agent
+  * CORECLR_PROFILER_PATH (.NET only): /opt/lib/newrelic-dotnet-agent/libNewRelicProfiler.so
 
 Refer to the [New Relic AWS Lambda Monitoring Documentation](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda) for instructions on completing your configuration by linking your AWS Account and Cloudwatch Log Streams to New Relic.
 

--- a/dotnet/publish-layers.sh
+++ b/dotnet/publish-layers.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+BUILD_DIR=lib # for .net can either be lib  or bin. See: https://docs.aws.amazon.com/lambda/latest/dg/packaging-layers.html
+DIST_DIR=dist
+
+DOTNET_DIST_ARM64=$DIST_DIR/dotnet.arm64.zip
+DOTNET_DIST_X86_64=$DIST_DIR/dotnet.x86_64.zip
+
+AGENT_DIST_ZIP=agent.zip
+
+source ../libBuild.sh
+
+function usage {
+    echo "./publish-layers.sh [dotnet]"
+}
+
+function build-dotnet-x86-64 {
+    echo "Building New Relic layer for .NET 6, 7 and 8 (x86_64)"
+    rm -rf $BUILD_DIR $DOTNET_DIST_X86_64
+    mkdir -p $DIST_DIR
+    get_agent amd64
+    # MAKE CONFIG CHANGES HERE
+    download_extension x86_64
+    zip -rq $DOTNET_DIST_X86_64 $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+    rm -rf $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+    echo "Build complete: ${DOTNET_DIST_X86_64}"
+}
+
+function publish-dotnet-x86-64 {
+    if [ ! -f $DOTNET_DIST_X86_64 ]; then
+        echo "Package not found: ${DOTNET_DIST_X86_64}"
+        exit 1
+    fi
+
+    for region in "${REGIONS_X86[@]}"; do
+      publish_layer $DOTNET_DIST_X86_64 $region dotnet x86_64
+    done
+}
+
+function build-dotnet-arm64 {
+    echo "Building New Relic layer for .NET 6, 7 and 8 (ARM64)"
+    rm -rf $BUILD_DIR $DOTNET_DIST_ARM64
+    mkdir -p $DIST_DIR
+    get_agent arm64
+    # MAKE CONFIG CHANGES HERE
+    download_extension arm64
+    zip -rq $DOTNET_DIST_ARM64 $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+    rm -rf $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
+    echo "Build complete: ${DOTNET_DIST_ARM64}"
+}
+
+function publish-dotnet-arm64 {
+    if [ ! -f $DOTNET_DIST_ARM64 ]; then
+        echo "Package not found: ${DOTNET_DIST_ARM64}"
+        exit 1
+    fi
+
+    for region in "${REGIONS_ARM[@]}"; do
+      publish_layer $DOTNET_DIST_ARM64 $region dotnet arm64
+    done
+}
+
+# exmaple https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_10.22.0_amd64.tar.gz
+function get_agent {
+    arch=$1
+    
+    url="https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_${AGENT_VERSION}_${arch}.tar.gz"
+    rm -rf $AGENT_DIST_ZIP
+    curl -L $url -o $AGENT_DIST_ZIP
+    mkdir -p $BUILD_DIR
+    tar -xvf $AGENT_DIST_ZIP -C ./$BUILD_DIR # under $BUILD_DIR/newrelic-dotnet-agent
+    rm -f $AGENT_DIST_ZIP
+}
+
+if [ -z $AGENT_VERSION ]; then
+    echo "Missing required AGENT_VERSION environment variable: ${AGENT_VERSION}."
+    exit 1
+fi
+
+case "${1:-default}" in
+    "dotnet")
+        build-dotnet-arm64
+        #publish-dotnet-arm64
+        build-dotnet-x86-64
+        #publish-dotnet-x86-64
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/dotnet/publish-layers.sh
+++ b/dotnet/publish-layers.sh
@@ -13,7 +13,7 @@ AGENT_DIST_ZIP=agent.zip
 source ../libBuild.sh
 
 function usage {
-    echo "./publish-layers.sh [dotnet]"
+    echo "./publish-layers.sh"
 }
 
 function build-dotnet-x86-64 {
@@ -79,14 +79,8 @@ if [ -z $AGENT_VERSION ]; then
     exit 1
 fi
 
-case "${1:-default}" in
-    "dotnet")
-        build-dotnet-arm64
-        #publish-dotnet-arm64
-        build-dotnet-x86-64
-        #publish-dotnet-x86-64
-        ;;
-    *)
-        usage
-        ;;
-esac
+build-dotnet-arm64
+publish-dotnet-arm64
+build-dotnet-x86-64
+publish-dotnet-x86-64
+

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -226,7 +226,7 @@ function publish_layer {
     fi
 
     if [[ $runtime_name == "dotnet" ]]
-    then compat_list=("dotnet6" "dotnet7" "dotnet8")
+    then compat_list=("dotnet6" "dotnet8")
     fi
 
     echo "Uploading ${layer_archive} to s3://${bucket_name}/${s3_key}"

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -134,6 +134,9 @@ function layer_name_str() {
     "ruby3.3")
       rt_part="Ruby33"
       ;;
+    "dotnet")
+      rt_part="Dotnet"
+      ;;
     esac
 
     case $2 in
@@ -188,6 +191,9 @@ function s3_prefix() {
     "ruby3.3")
       name="nr-ruby3.3"
       ;;
+    "dotnet")
+      name="nr-dotnet"
+      ;;
     esac
 
     echo $name
@@ -217,6 +223,10 @@ function publish_layer {
     compat_list=( $runtime_name )
     if [[ $runtime_name == "provided" ]]
     then compat_list=("provided" "provided.al2" "provided.al2023" "dotnetcore3.1" "dotnet6")
+    fi
+
+    if [[ $runtime_name == "dotnet" ]]
+    then compat_list=("dotnet6" "dotnet7" "dotnet8")
     fi
 
     echo "Uploading ${layer_archive} to s3://${bucket_name}/${s3_key}"


### PR DESCRIPTION
Similar to the Python Agent, we don't need to build anything. We can grab the necessary files from the download site to publish.

The same Agent binaries support all the possible .NET Lambda runtimes (.NET 6, 7, and 8), so the only layers that need to be created are x64/ARM64.

Next step will be to add tag creation to our Agent release process.