### PR TITLE
fix: Remove the dotnet6 runtime from the NewRelicLambdaExtension.

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -222,7 +222,7 @@ function publish_layer {
 
     compat_list=( $runtime_name )
     if [[ $runtime_name == "provided" ]]
-    then compat_list=("provided" "provided.al2" "provided.al2023" "dotnetcore3.1" "dotnet6")
+    then compat_list=("provided" "provided.al2" "provided.al2023" "dotnetcore3.1")
     fi
 
     if [[ $runtime_name == "dotnet" ]]


### PR DESCRIPTION
Removes the dotnet6 runtime from the NewRelicLambdaExtension by removing it from the "provided" set of runtimes.

With the introduction of the .NET Agent layers, having dotnet6 listed as a runtime on the NewRelicLambdaExtension is breaking tests for the lambda cli and will break scripting for customers.   The CLI will fail and exit if more than one layer exists for a specific runtime and architecture pair when being run from a script and not an interactive terminal.  Looking over the available layers, I am not seeing any other language agent layers that have duplicates.