### PR TITLE
chore: Updated layer-discovery site URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains source code and utilities to build and publish New Relic's public AWS Lambda layers.
 
-Most users should use our published layers which are chosen automatically via the [CLI tool](https://github.com/newrelic/newrelic-lambda-cli). Those layers are published to be public and are available [here](https://nr-layers.iopipe.com).
+Most users should use our published layers which are chosen automatically via the [CLI tool](https://github.com/newrelic/newrelic-lambda-cli). Those layers are published to be public and are available [here](https://layers.newrelic-external.com/).
 
 This tool is released for users seeking to deploy their own copies of the New Relic Lambda Layers into their accounts, or to modify and publish their own customized wrapper layers.
 


### PR DESCRIPTION
This repo's README has directed users to a website that displays the latest ARN of various layers. The site responds to both https://layers.newrelic-external.com/ and https://nr-layers.iopipe.com/. Both URLs are correct, but the latter URL could present some confusion for users. (For context, New Relic acquired IOpipe in 2019, and the corresponding layer discovery site was launched to provide layers helping IOpipe customers onboard to New Relic.) These layers could be used by customers of either to send telemetry to New Relic, and the web content is the same no matter which URL is used, so updating the URL in this document is merely a copyediting change. 