### PR TITLE
Bashscript update to auto publish layers to docker hub.

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -315,3 +315,26 @@ function publish_docker_ecr {
     # delete dockerfile
     rm -rf Dockerfile.ecrImage
 }
+
+function publish_docker_hub {
+    layer_archive=$1
+    runtime_name=$2
+    arch=$3
+    if [[ ${arch} =~ 'arm64' ]];
+    then arch_flag="-arm64"
+    else arch_flag=""
+    fi
+    version_flag=$(echo "$runtime_name" | sed 's/[^0-9]//g')
+    language_flag=$(echo "$runtime_name" | sed 's/[0-9].*//')
+    # Remove 'dist/' prefix
+    if [[ $layer_archive == dist/* ]]; then
+      file_without_dist="${layer_archive#dist/}"
+      echo "File without 'dist/': $file_without_dist"
+    else
+      file_without_dist=$layer_archive
+      echo "File does not start with 'dist/': $file_without_dist"
+    fi
+    docker build -t $language_flag:${version_flag[$index]} --build-arg docker_arn=${arns[$index]} .
+    docker tag $language_flag:${version_flag[$index]} newrelic/newrelic-lambda-layers:$language_flag-${version_flag[$index]}
+    docker push newrelic/newrelic-lambda-layers:$language_flag-${version_flag[$index]}
+}


### PR DESCRIPTION
Created a Docket Hub repository under Newrelic organisation. This Docker image repository contains New Relic Lambda Layer images for Java, Node.js, and Python applications. These images facilitate seamless integration of New Relic's monitoring capabilities into your AWS Lambda functions.

To download the latest Docker image for the Java Lambda layer, use:
_**docker pull newrelic/newrelic-lambda-layers-java:latest**_
To pull a specific version of the Java Lambda layer image, use:
_**docker pull newrelic/newrelic-lambda-layers-java:<version>**_


