### PR TITLE
remove python3.7 layer

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v4
       - name: Check Tag

--- a/python/publish-layers.sh
+++ b/python/publish-layers.sh
@@ -11,7 +11,6 @@ PY310_DIST_ARM64=$DIST_DIR/python310.arm64.zip
 PY311_DIST_ARM64=$DIST_DIR/python311.arm64.zip
 PY312_DIST_ARM64=$DIST_DIR/python312.arm64.zip
 
-PY37_DIST_X86_64=$DIST_DIR/python37.x86_64.zip
 PY38_DIST_X86_64=$DIST_DIR/python38.x86_64.zip
 PY39_DIST_X86_64=$DIST_DIR/python39.x86_64.zip
 PY310_DIST_X86_64=$DIST_DIR/python310.x86_64.zip
@@ -25,30 +24,6 @@ function usage {
     echo "./publish-layers.sh [python3.7|python3.8|python3.9|python3.10|python3.11|python3.12]"
 }
 
-function build-python37-x86 {
-    echo "Building New Relic layer for python3.7 (x86_64)"
-    rm -rf $BUILD_DIR $PY37_DIST_X86_64
-    mkdir -p $DIST_DIR
-    pip install --no-cache-dir -qU newrelic -t $BUILD_DIR/lib/python3.7/site-packages
-    cp newrelic_lambda_wrapper.py $BUILD_DIR/lib/python3.7/site-packages/newrelic_lambda_wrapper.py
-    cp -r newrelic_lambda $BUILD_DIR/lib/python3.7/site-packages/newrelic_lambda
-    find $BUILD_DIR -name '__pycache__' -exec rm -rf {} +
-    download_extension x86_64
-    zip -rq $PY37_DIST_X86_64 $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
-    rm -rf $BUILD_DIR $EXTENSION_DIST_DIR $EXTENSION_DIST_PREVIEW_FILE
-    echo "Build complete: ${PY37_DIST_X86_64}"
-}
-
-function publish-python37-x86 {
-    if [ ! -f $PY37_DIST_X86_64 ]; then
-        echo "Package not found: ${PY37_DIST_X86_64}"
-        exit 1
-    fi
-
-    for region in "${REGIONS_X86[@]}"; do
-      publish_layer $PY37_DIST_X86_64 $region python3.7 x86_64
-    done
-}
 
 function build-python38-arm64 {
     echo "Building New Relic layer for python3.8 (arm64)"
@@ -301,11 +276,6 @@ function publish-python312-x86 {
 }
 
 case "$1" in
-    "python3.7")
-        build-python37-x86
-        publish-python37-x86
-        publish_docker_ecr $PY37_DIST_X86_64 python3.7 x86_64
-        ;;
     "python3.8")
         build-python38-arm64
         publish-python38-arm64

--- a/python/publish-layers.sh
+++ b/python/publish-layers.sh
@@ -21,7 +21,7 @@ PY312_DIST_X86_64=$DIST_DIR/python312.x86_64.zip
 source ../libBuild.sh
 
 function usage {
-    echo "./publish-layers.sh [python3.7|python3.8|python3.9|python3.10|python3.11|python3.12]"
+    echo "./publish-layers.sh [python3.8|python3.9|python3.10|python3.11|python3.12]"
 }
 
 


### PR DESCRIPTION
As per [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated), Python 3.7 has been deprecated
Python 3.7 | python3.7 | Amazon Linux | Dec 4, 2023
-- | -- | -- | --


