### PR TITLE
publish extension only ecr images

### DIFF
--- a/extension/publish-layer.sh
+++ b/extension/publish-layer.sh
@@ -49,6 +49,8 @@ function publish-layer-arm64 {
 
 build-layer-x86
 publish-layer-x86
+publish_docker_ecr $EXTENSION_DIST_ZIP_X86_64 extension x86_64
 
 build-layer-arm64
 publish-layer-arm64
+publish_docker_ecr $EXTENSION_DIST_ZIP_ARM64 extension arm64

--- a/libBuild.sh
+++ b/libBuild.sh
@@ -269,6 +269,9 @@ function publish_docker_ecr {
     version_flag=$(echo "$runtime_name" | sed 's/[^0-9]//g')
     language_flag=$(echo "$runtime_name" | sed 's/[0-9].*//')
 
+    if [[ ${runtime_name} =~ 'extension' ]];
+    then version_flag=$EXTENSION_VERSION
+    fi
 
     # Remove 'dist/' prefix
     if [[ $layer_archive == dist/* ]]; then


### PR DESCRIPTION
Release extension only images in the format [newrelic-lambda-layers-extension] in the public repo for New Relic lambda images: https://gallery.ecr.aws/x6n7b2o2?page=1.

Currently, we have [x6n7b2o2/newrelic-lambda-layers-lambdaextension](https://gallery.ecr.aws/x6n7b2o2/newrelic-lambda-layers-lambdaextension), which was not released with github actions.