### PR TITLE
fix: Create .NET layer for docker

### DIFF
--- a/dotnet/publish-layers.sh
+++ b/dotnet/publish-layers.sh
@@ -37,6 +37,8 @@ function publish-dotnet-x86-64 {
     for region in "${REGIONS_X86[@]}"; do
       publish_layer $DOTNET_DIST_X86_64 $region dotnet x86_64
     done
+
+    publish_docker_ecr $DOTNET_DIST_X86_64 dotnet x86_64
 }
 
 function build-dotnet-arm64 {
@@ -60,6 +62,8 @@ function publish-dotnet-arm64 {
     for region in "${REGIONS_ARM[@]}"; do
       publish_layer $DOTNET_DIST_ARM64 $region dotnet arm64
     done
+
+    publish_docker_ecr $DOTNET_DIST_ARM64 dotnet arm64
 }
 
 # exmaple https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_amd64.tar.gz


### PR DESCRIPTION
Somehow we missed this in our initial implementation. It's referenced in [our documentation](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/containerized-images/#dotnet) but we have never created one.