### PR TITLE
Resolve dotnet ecr image format issue

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -273,6 +273,11 @@ function publish_docker_ecr {
     version_flag=$EXTENSION_VERSION
     language_flag="lambdaextension"
     fi
+    
+    if [[ ${runtime_name} =~ 'dotnet' ]]; then
+    version_flag=""
+    arch_flag=${arch}
+    fi
 
     # Remove 'dist/' prefix
     if [[ $layer_archive == dist/* ]]; then


### PR DESCRIPTION
- Resolves issue related to publishing of docker ecr images for dotnet. PR [here](https://github.com/newrelic/newrelic-lambda-layers/pull/271)
- Currently we see following error in the [test run](https://github.com/chaudharysaket/newrelic-lambda-layers/actions/runs/10805282963/job/29972132934):
```
docker tag layer-nr-image-dotnet--arm64:latest public.ecr.aws/<test-account>/newrelic-lambda-layers-dotnet:-arm64
Error parsing reference: "public.ecr.aws/<test-account>/newrelic-lambda-layers-dotnet:-arm64" is not a valid repository/tag: invalid reference format
```
- The [publish_docker_ecr code](https://github.com/newrelic/newrelic-lambda-layers/blob/57122f88fc82cbcd7d3480638c16a3cc572ee8ae/libBuild.sh#L265) creates arch_flag with `-` for arm and no arch_flag for `x86_64`. The `:-` is an invalid format for ECR images.
- We will use arch_flag provided by docker release command in the dotnet/publish-layers.sh that is  `publish_docker_ecr image_zip runtime arch_flag`
