### PR TITLE
Support handler methods without any argument

### DIFF
--- a/java/src/main/java/com/newrelic/java/JavaClassLoader.java
+++ b/java/src/main/java/com/newrelic/java/JavaClassLoader.java
@@ -75,8 +75,7 @@ public class JavaClassLoader implements RequestHandler<Object, Object> {
         this.inputType = inputType;
         if (numberOfArguments == 0) {
             this.executor = (input, context) -> methodHandle.invoke();
-        } else
-        if (numberOfArguments == 1) {
+        } else if (numberOfArguments == 1) {
             this.executor = (input, context) -> methodHandle.invokeWithArguments(input);
         } else {
             this.executor = methodHandle::invokeWithArguments;

--- a/java/src/main/java/com/newrelic/java/JavaClassLoader.java
+++ b/java/src/main/java/com/newrelic/java/JavaClassLoader.java
@@ -39,13 +39,13 @@ public class JavaClassLoader implements RequestHandler<Object, Object> {
         for (Method method : loadedClass.getMethods()) {
             if (isUserHandlerMethod(method, methodName, loadedClass)) {
                 methodReturnType = method.getReturnType();
-                if (method.getParameterTypes().length == 1) {
+                numberOfArguments = method.getParameterTypes().length;
+                if (numberOfArguments == 1) {
                     methodInputType = method.getParameterTypes()[0];
-                } else if (method.getParameterTypes().length == 2) {
+                } else if (numberOfArguments == 2) {
                     methodInputType = method.getParameterTypes()[0];
                     methodContextType = method.getParameterTypes()[1];
                 }
-                numberOfArguments = method.getParameterTypes().length;
                 break;
             }
         }
@@ -114,10 +114,7 @@ public class JavaClassLoader implements RequestHandler<Object, Object> {
     }
 
     private Object mappingInputToHandlerType(Object inputParam, Class<?> inputType) throws JsonProcessingException {
-        if (inputType == null) {
-            return inputParam;
-        }
-        if (inputType.isAssignableFrom(Number.class) || inputType.isAssignableFrom(String.class)) {
+        if (inputType == null || inputType.isAssignableFrom(Number.class) || inputType.isAssignableFrom(String.class)) {
             return inputParam;
         } else if (LambdaEventSerializers.isLambdaSupportedEvent(inputType.getName())) {
             PojoSerializer<?> serializer = LambdaEventSerializers.serializerFor(inputType, JavaClassLoader.class.getClassLoader());

--- a/java/src/test/java/com/newrelic/java/JavaClassLoaderTest.java
+++ b/java/src/test/java/com/newrelic/java/JavaClassLoaderTest.java
@@ -51,4 +51,10 @@ public class JavaClassLoaderTest {
         Assert.assertEquals("Hello World", loader.handleRequest(STRING_INPUT, null));
     }
 
+    @Test
+    public void testWithoutArgumentRequestHandler() throws ReflectiveOperationException {
+        JavaClassLoader loader = JavaClassLoader.initializeRequestHandler(PojoHandlerWithNoArgument.class, "handleRequest");
+        Assert.assertEquals("Hello World!", loader.handleRequest(INPUT_AS_OBJECT, null));
+    }
+
 }

--- a/java/src/test/java/com/newrelic/java/PojoHandlerWithNoArgument.java
+++ b/java/src/test/java/com/newrelic/java/PojoHandlerWithNoArgument.java
@@ -1,0 +1,10 @@
+package com.newrelic.java;
+
+public class PojoHandlerWithNoArgument {
+
+
+    public String handleRequest() {
+        return "Hello World!";
+    }
+
+}


### PR DESCRIPTION
This PR adds ability to run custom handlers that executes method that doesn't require any arguments. This is fully supported by AWS Lambda environment. The typical example are the scheduled functions where the cron CloudWatch event often doesn't provide any additional value to the function. Once the request goes through this layer, the execution currently fails because the executor expects having either one or two arguments.