### PR TITLE
Add Commons-Logging Dependency

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation("com.amazonaws:aws-lambda-java-serialization:1.0.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7.1")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-joda:2.12.2")
+    implementation('commons-logging:commons-logging:1.3.4')
 
     testImplementation("junit:junit:4.13")
     testImplementation('com.github.stefanbirkner:system-lambda:1.2.0')


### PR DESCRIPTION
Replaces the version of `commons-logging` that is pulled in via the `java-aws-lambda:2.2.0` dependency.

Resolves Issue #283