### PR TITLE
Update extension version

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -60,7 +60,7 @@ EXTENSION_DIST_DIR=extensions
 EXTENSION_DIST_ZIP=extension.zip
 EXTENSION_DIST_PREVIEW_FILE=preview-extensions-ggqizro707
 
-EXTENSION_VERSION=2.3.14
+EXTENSION_VERSION=2.3.15
 
 function list_all_regions {
     aws ec2 describe-regions \


### PR DESCRIPTION
Update lambda layer release script to use latest Extension [v2.3.15](https://github.com/newrelic/newrelic-lambda-extension/releases/tag/v2.3.15).