### PR TITLE
Chore: bumps up codecov-action

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -46,7 +46,7 @@ jobs:
           ./publish-layers.sh build-publish-nodejs${{ matrix.node-version }}x-ecr-image
       - name: Upload Unit Test Coverage
         if: steps.node-check-tag.outputs.match == 'true'
-        uses: codecov/codecov-action@v5.0.7
+        uses: codecov/codecov-action@v5.3.1
         with:
          token: ${{ secrets.CODECOV_TOKEN }}
          files: ./nodejs/coverage/unit/lcov.info


### PR DESCRIPTION
### Description: 
- Updating the version which resolves failing while releasing `node.js` layers. 
- Since in actions 5 [code-cov](https://github.com/codecov/codecov-action) has updated the `file` to `files` so updated it as per readme in `code-cov`. 