### PR TITLE
update exception handling

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
 

--- a/python/newrelic_lambda_wrapper.py
+++ b/python/newrelic_lambda_wrapper.py
@@ -61,8 +61,11 @@ def get_handler():
             )
 
         module = importlib.import_module(module_path.replace("/", "."))
+    except ImportError as e:
+            raise ImportError("Failed to import module '%s': %s" % (module_path, e))
     except Exception as e:
-        raise ImportError("Failed to import module '%s': %s" % (module_path, e))
+        raise type(e)(f"Error while importing '{module_path}': {type(e).__name__} {str(e)}").with_traceback(e.__traceback__)
+    
 
     try:
         handler = getattr(module, handler_name)


### PR DESCRIPTION
- As mentioned in the [issue](https://github.com/newrelic/newrelic-lambda-layers/issues/281), the `ImportError` is masking other errors during initializing of module and not providing proper traceback.
- Updated Exception such that other exceptions such as `KeyError` or `ValueError` during import of module get raised properly.
- Remove python 3.7 from CI workflow as it has been deprecated