### PR TITLE
fix: Added instruction for using the ESM Loader for Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Refer to the [New Relic AWS Lambda Monitoring Documentation](https://docs.newrel
 
 ## Support for ES Modules (Node.js)
 
-AWS announced support for Node 18 as a Lambda runtime in late 2022, introducing `aws-sdk` version 3 for Node 18 only. This version of `aws-sdk` patches `NODE_PATH`, so ESM-supporting functions using `import` and top-level `await` should work as expected with Lambda Layer releases `v9.8.1.1` and above (Numerical layer versions vary by region and runtime). To configure the layer to leverage `import`, add the environment variable `NEW_RELIC_USE_ESM: true`.
+AWS announced support for Node 18 as a Lambda runtime in late 2022, introducing `aws-sdk` version 3 for Node 18 only. This version of `aws-sdk` patches `NODE_PATH`, so ESM-supporting functions using `import` and top-level `await` should work as expected with Lambda Layer releases `v9.8.1.1` and above (Numerical layer versions vary by region and runtime). To configure the layer to leverage `import`, add the environment variable `NEW_RELIC_USE_ESM: true`, and add this environment variable to use our ESM loader: `NODE_OPTIONS: --experimental-loader newrelic/esm-loader.mjs`.
 
 Note that if you use layer-installed instrumentation with the `NEW_RELIC_USE_ESM` environment variable, your function must use promises or async/await; callback based functions are not supported. The Node wrapper uses a [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) to attach to your function, which is an asynchronous operation. If you still need support for callback based functions, you will have to use the CommonJS based wrapper, which can be done by removing the `NEW_RELIC_USE_ESM` environment variable.
 


### PR DESCRIPTION
In ESM, the Node agent uses an experimental loader flag to load some dependencies for instrumentation. This PR adds an instruction for using this loader in Lambda. 