### PR TITLE
ci: Fixed publishing ecr images for node layer

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -43,7 +43,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           cd nodejs
-          ./publish-layers.sh build-publish-{{ matrix.node-version }}-ecr-image
+          ./publish-layers.sh build-publish-${{ matrix.node-version }}-ecr-image
       - name: Upload Unit Test Coverage
         if: steps.node-check-tag.outputs.match == 'true'
         uses: codecov/codecov-action@v5.3.1


### PR DESCRIPTION
During #319 I missed a `$` to reference the node version variable