### PR TITLE
Update Ruby GitHub Actions config for Ubuntu runner

### DIFF
--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         ruby-version: [3.2, 3.3]
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
+      - uses: actions/checkout@v4.2.2
       - name: Use Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+        uses: ruby/setup-ruby@v1.226.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Check Tag

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: actions/checkout@v4.2.2
+      - uses: ruby/setup-ruby@v1.226.0
         with:
           ruby-version: '3.3'
       - run: bundle
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: actions/checkout@v4.2.2
+      - uses: ruby/setup-ruby@v1.226.0
         with:
           ruby-version: '3.3'
       # Node.js powers serverless-offline, used for unit tests


### PR DESCRIPTION
- Currently, there is issue with[ Ruby Layer publish workflow](https://github.com/newrelic/newrelic-lambda-layers/actions/runs/13053353305), which is giving following error:

```
Error: The current runner (ubuntu-24.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).
```
 - Update the workflow config to resolve the compatibility issue. 