### PR TITLE
Fix Python Agent Build Determinism

### DIFF
--- a/python/publish-layers.sh
+++ b/python/publish-layers.sh
@@ -70,18 +70,17 @@ function publish_python_layer {
         echo "Package not found: ${ZIP}"
         exit 1
     fi
-    if [arch == "arm64"]; then
-        for region in "${REGIONS_ARM[@]}"; do
-            echo "Publishing layer for python${python_version} (${arch}) to region ${region}"
-            publish_layer ${ZIP} $region python${python_version} ${arch} $NEWRELIC_AGENT_VERSION
-        done
+
+    if [[ "${arch}" == "arm64" ]]; then
+        REGIONS=("${REGIONS_ARM[@]}");
     else
-        for region in "${REGIONS_X86[@]}"; do
-            echo "Publishing layer for python${python_version} (${arch}) to region ${region}"
-            publish_layer ${ZIP} $region python${python_version} ${arch} $NEWRELIC_AGENT_VERSION
-        done
+        REGIONS=("${REGIONS_X86[@]}");
     fi
-    
+
+    for region in "${REGIONS[@]}"; do
+        echo "Publishing layer for python${python_version} (${arch}) to region ${region}"
+        publish_layer ${ZIP} $region python${python_version} ${arch} $NEWRELIC_AGENT_VERSION
+    done
 }
 
 


### PR DESCRIPTION
# Overview

* Fix issue where Python Agent would install the latest available version and release it for a given tag, rather than the exactly correct version.
  * This issue has the potential to cause a race condition between the CDN for PyPi and the publishing of layers built here to cause the incorrect Python Agent version to be released.
  * This is especially pressing considering the drastically reduced lag between PyPi publish steps and this one, where we've had issues recently on the InitContainer repo with the version not being available yet.
* Deduplicate code for region specific builds in `python/publish_layers.sh`.
* Fix bug in architecture detection where a missing `$` caused all layers to be treated as x86.
  * [Example](https://github.com/newrelic/newrelic-lambda-layers/actions/runs/14652430417/job/41121118879#step:6:23)