### PR TITLE
add Ruby 3.4 to release workflow

### DIFF
--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.2, 3.3]
+        ruby-version: [3.2, 3.3, 3.4]
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Use Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
- add Ruby 3.4 to release workflow