### PR TITLE
test: fixed integration nodejs tests

### DIFF
--- a/nodejs/test/integration/serverless.yml
+++ b/nodejs/test/integration/serverless.yml
@@ -2,7 +2,7 @@ service: integration-tests
 frameworkVersion: '3'
 
 custom:
-  NODE_RUNTIME: ${env:NODE_RUNTIME}
+  NODE_RUNTIME: ${env:NODE_RUNTIME, 'nodejs20.x'}
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
This PR fixes a regression from [this commit](https://github.com/newrelic/newrelic-lambda-layers/commit/3055ce0ff6e48091e9896138333ebacbfd90cf65#diff-afb0d0b832a0ccfb7abdfc81fb479bf3d93946a232148cfffb773c2478a36769L5). It looks like when removing Node 18, we removed the custom runtime so the tests weren't running in any node version.  
