### PR TITLE
Update Ruby lambda wrapper

### DIFF
--- a/ruby/newrelic_lambda_wrapper.rb
+++ b/ruby/newrelic_lambda_wrapper.rb
@@ -117,8 +117,8 @@ end
 
 # warm the memoization cache so that the very first customer method invocation
 # isn't made to wait
-NewRelicLambdaWrapper.require_ruby_agent
 NewRelicLambdaWrapper.method_name_and_namespace
+NewRelicLambdaWrapper.require_ruby_agent
 
 def handler(event:, context:)
   method_name, namespace = NewRelicLambdaWrapper.method_name_and_namespace


### PR DESCRIPTION
The ruby agent was being loaded before gems that needed to be instrumented, resulting in instrumentation not being installed for any gems not included in the ruby language. This change reorders the agent loading to happen after loading the file that requires the gems that will be used by the function