### PR TITLE
Fix issue where /java/ not visible from dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 *.md
 LICENSE
 dockerfiles
-java
 ruby
 dotnet
 __pycache__

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     implementation("io.opentracing:opentracing-util:0.33.0")
     implementation("com.newrelic.opentracing:newrelic-java-lambda:2.2.5")
-    implementation("com.newrelic.opentracing:java-aws-lambda:3.1.0")
+    implementation("com.newrelic.opentracing:java-aws-lambda:3.2.0")
     implementation("com.amazonaws:aws-lambda-java-events:3.15.0")
     implementation("com.amazonaws:aws-lambda-java-core:1.2.3")
     implementation("com.amazonaws:aws-lambda-java-serialization:1.0.0")


### PR DESCRIPTION
This resolves an issue where publish steps of the open tracing java layers in GHA fail.