### PR TITLE
chore: Updated `serverless-offline` test dependencies in nodejs to `13.10.0`

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -19,7 +19,7 @@
         "node-fetch": "^2.6.11",
         "proxyquire": "^2.1.3",
         "serverless": "^3.40.0",
-        "serverless-offline": "^13.9.0",
+        "serverless-offline": "^13.10.0",
         "tap": "^16.3.0",
         "testdouble": "^3.20.2"
       }
@@ -20359,9 +20359,9 @@
       }
     },
     "node_modules/serverless-offline": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.9.0.tgz",
-      "integrity": "sha512-r/GU1FcgUbrhUzPJ5BOpni6JXhHVhxksYQH8d3S4alx4IZQo3E9Q8fT2z8Mvh+d0rfQ1Y0kHvyeKJ126rleGfg==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.10.0.tgz",
+      "integrity": "sha512-TchZKgG9bLos347h4lHbuXgVLoODxx5mafcCTDT3CGWWcbv0k92L7/xoMTMCCvWGzeOC+7DMcXxJ0vSGbMjT7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -39583,9 +39583,9 @@
       }
     },
     "serverless-offline": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.9.0.tgz",
-      "integrity": "sha512-r/GU1FcgUbrhUzPJ5BOpni6JXhHVhxksYQH8d3S4alx4IZQo3E9Q8fT2z8Mvh+d0rfQ1Y0kHvyeKJ126rleGfg==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.10.0.tgz",
+      "integrity": "sha512-TchZKgG9bLos347h4lHbuXgVLoODxx5mafcCTDT3CGWWcbv0k92L7/xoMTMCCvWGzeOC+7DMcXxJ0vSGbMjT7w==",
       "dev": true,
       "requires": {
         "@aws-sdk/client-lambda": "^3.636.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -53,7 +53,7 @@
     "node-fetch": "^2.6.11",
     "proxyquire": "^2.1.3",
     "serverless": "^3.40.0",
-    "serverless-offline": "^13.9.0",
+    "serverless-offline": "^13.10.0",
     "tap": "^16.3.0",
     "testdouble": "^3.20.2"
   }


### PR DESCRIPTION
Nodejs enabled tests to run on node 24 but this dependency version wasn't bumped. V13.10.0 has node runtime 24 added. 