### PR TITLE
fix: resolve broken pipe and JSONDecodeError in poll-validation.sh

### DIFF
--- a/.github/scripts/poll-validation.sh
+++ b/.github/scripts/poll-validation.sh
@@ -99,9 +99,13 @@ while [[ $SECONDS -lt $end ]]; do
       exit 0
     else
       echo "FAILED: ${RUNTIME}"
-      echo "$result" | python3 - <<'PYEOF'
-import json, sys
-d = json.load(sys.stdin)
+      # Write result to a temp file — avoids the bash stdin conflict between
+      # a pipe and a heredoc both trying to own python3's stdin (broken pipe bug).
+      printf '%s' "$result" > /tmp/val_result.json
+      python3 <<'PYEOF'
+import json
+with open('/tmp/val_result.json') as f:
+    d = json.load(f)
 for variant in ("standard", "slim"):
     section = d.get(variant) or {}
     for f in section.get("functions", []):


### PR DESCRIPTION
## What

Fixes a silent crash in `poll-validation.sh` that happens when layer validation fails. The script was supposed to print which specific functions failed and why, but instead it threw a **broken pipe + JSONDecodeError**, so the failure detail was never shown.

## Why it broke

The original code piped `$result` into `python3` while also using a heredoc for the script body — both trying to own Python's stdin at the same time. Bash gives the heredoc priority, leaving the pipe unread → broken pipe. Python then reads an empty stdin → JSONDecodeError.

```bash
# broken
echo "$result" | python3 - <<'PYEOF'
import json, sys
d = json.load(sys.stdin)  # sys.stdin is empty, crash
PYEOF
```

## Fix

Write the result to a temp file and read from there, so there's no stdin conflict.

```bash
printf '%s' "$result" > /tmp/val_result.json
python3 <<'PYEOF'
import json
with open('/tmp/val_result.json') as f:
    d = json.load(f)
PYEOF
```

## Test Plan

- [ ] Validation failure run: per-function failure detail prints correctly, no broken pipe error
- [ ] Validation pass run: no regression in the success path

🤖 Generated with [Claude Code](https://claude.com/claude-code)