### PR TITLE
[Java] Version bump: Jackson 

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:2.18.6"))
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.22.0"))
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-joda")
 


### PR DESCRIPTION
This PR bumps the Java Jackson BOM dependency to facilitate resolution of [customer identified CVEs](https://github.com/orgs/newrelic/projects/87/views/1?pane=issue&itemId=207333906&issue=newrelic%7Cnewrelic-java-agent%7C2969).
