### PR TITLE
[Java] Bump Jackson dependency version

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:2.22.0"))
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.22.1"))
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-joda")
 


### PR DESCRIPTION
A few CVEs cropped up recently related to our Jackson core/databind dependencies:
High GHSA-r7wm-3cxj-wff9 com.fasterxml.jackson.core:jackson-core
Medium CVE-2026-54515 com.fasterxml.jackson.core:jackson-databind
Medium CVE-2026-59889 com.fasterxml.jackson.core:jackson-databind

There has been a new (7/8/26) version of the Jackson BOM [released](https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom/2.22.1/dependencies) which addresses these vulnerabilities. The documented patches (for 2.22.1) can be found below:
- [High GHSA GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
- [Medium CVE-2026-54515](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-5jmj-h7xm-6q6v)
- [Medium CVE-2026-59889](https://nvd.nist.gov/vuln/detail/CVE-2026-59889)