### PR TITLE
fix: add missing permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,6 +10,9 @@ on:
             - 'nodejs/**'
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
 
     lint:

--- a/.github/workflows/publish-dotnet.yml
+++ b/.github/workflows/publish-dotnet.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # ── Job 1: Publish staging (dotnet10) ────────────────────────────────────
   stage-dotnet:

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # ── Job 1: Publish staging (extension) ───────────────────────────────────
   stage-extension:

--- a/.github/workflows/publish-java-agent.yml
+++ b/.github/workflows/publish-java-agent.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v**_java-agent
 
+permissions:
+  contents: read
+
 jobs:
   publish-java-agent:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # ── Job 1: Build + publish staging (java25 only) ──────────────────────────
   stage-java:

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # ── Job 1: Build + publish staging (node24 only) ──────────────────────────
   stage-node:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # ── Job 1: Publish staging (python3.14 only) ──────────────────────────────
   stage-python:

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # ── Job 1: Publish staging (ruby3.4 only) ────────────────────────────────
   stage-ruby:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,9 @@ on:
       - "python/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [ push, workflow_dispatch ]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - 'ruby/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-layer.yml
+++ b/.github/workflows/validate-layer.yml
@@ -43,6 +43,9 @@ on:
       SLACK_VALIDATION_WEBHOOK:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- CodeQL (`actions/missing-workflow-permissions`) flagged 12 workflows in this repo for not declaring an explicit `permissions:` block, leaving the default `GITHUB_TOKEN` scope implicit.
- Added least-privilege `permissions:` blocks:
  - `nodejs.yml`, `python.yml`, `ruby.yml` → `contents: read` (checkout/lint/test only, no write needed)
  - `validate-layer.yml`, `publish-java-agent.yml` → `contents: read` (checkout + build/publish scripts, no GitHub API calls)
  - `publish-java.yml`, `publish-node.yml`, `publish-python.yml`, `publish-ruby.yml`, `publish-dotnet.yml`, `publish-extension.yml` → `contents: read`, `actions: read` (the `notify-slack` job in each calls `gh api repos/.../actions/runs/{id}/jobs` and `gh run download` via the `notify-slack-layer` composite action to build the Slack release summary — needs `actions: read`)
  - `repolinter.yml` → `contents: read`, `issues: write` (repolinter-action opens a GitHub issue when findings exist)
- `dependency-submission.yml` already declared explicit permissions and was left unchanged.
- None of these workflows post PR comments, so no `pull-requests: write` was added anywhere.

Resolves NR-560188.

## Test plan
- [x] Validated all 12 edited workflow files parse as valid YAML
- [x] Confirmed via composite-action source (`notify-slack-layer`, `region-retry`) which jobs actually call the GitHub API vs. only use artifacts (artifact upload/download uses the runtime token, not `GITHUB_TOKEN`, so no extra permission needed there)
- [ ] Confirm CI (`nodejs.yml`, `python.yml`, `ruby.yml`, `repolinter.yml`) still passes on this PR
- [ ] Confirm a subsequent tagged publish run (dotnet/extension/java/node/python/ruby) still succeeds end-to-end, including the Slack notification step