### PR TITLE
chore: updating extension fetch link to rust extension

### DIFF
--- a/libBuild.sh
+++ b/libBuild.sh
@@ -64,7 +64,7 @@ function list_all_regions {
 function fetch_extension {
     arch=$1
 
-    url="https://github.com/newrelic/newrelic-lambda-extension/releases/download/v${EXTENSION_VERSION}/newrelic-lambda-extension.${arch}.zip"
+    url="https://github.com/newrelic/newrelic-lambda-extension-rust/releases/download/v${EXTENSION_VERSION}/newrelic-lambda-extension.${arch}.zip"
     rm -rf $EXTENSION_DIST_DIR $EXTENSION_DIST_ZIP
     curl -L $url -o $EXTENSION_DIST_ZIP
 }


### PR DESCRIPTION
Updating URL to fetch extension from Go extension repo to the rust extension repo.