### PR TITLE
fix: enable NEW_RELIC_WORKER_THREADS_ENABLED by default under LMI

### DIFF
--- a/nodejs/esm.mjs
+++ b/nodejs/esm.mjs
@@ -12,6 +12,14 @@ if (process.env.LAMBDA_TASK_ROOT && typeof process.env.NEW_RELIC_SERVERLESS_MODE
   delete process.env.NEW_RELIC_SERVERLESS_MODE_ENABLED
 }
 
+// LMI runs multiple invocations concurrently within one execution environment.
+// The agent's worker_threads instrumentation must be on for its context manager
+// to track concurrent invocations correctly; leaving it off is what causes
+// invocations to hang until the function times out.
+if (process.env.AWS_LAMBDA_INITIALIZATION_TYPE === 'lambda-managed-instances') {
+  process.env.NEW_RELIC_WORKER_THREADS_ENABLED = process.env.NEW_RELIC_WORKER_THREADS_ENABLED || 'true'
+}
+
 function getHandlerPath() {
   let handler
   const { NEW_RELIC_LAMBDA_HANDLER } = process.env

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -10,6 +10,14 @@ if (process.env.LAMBDA_TASK_ROOT && typeof process.env.NEW_RELIC_SERVERLESS_MODE
   delete process.env.NEW_RELIC_SERVERLESS_MODE_ENABLED
 }
 
+// LMI runs multiple invocations concurrently within one execution environment.
+// The agent's worker_threads instrumentation must be on for its context manager
+// to track concurrent invocations correctly; leaving it off is what causes
+// invocations to hang until the function times out.
+if (process.env.AWS_LAMBDA_INITIALIZATION_TYPE === 'lambda-managed-instances') {
+  process.env.NEW_RELIC_WORKER_THREADS_ENABLED = process.env.NEW_RELIC_WORKER_THREADS_ENABLED || 'true'
+}
+
 const newrelic = require('newrelic')
 const fs = require('node:fs')
 const path = require('node:path')

--- a/nodejs/test/unit/lmiWorkerThreads.tap.js
+++ b/nodejs/test/unit/lmiWorkerThreads.tap.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const tap = require('tap')
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
+const utils = require('@newrelic/test-utilities')
+
+tap.test('Layer Handler - LMI worker_threads default (CJS)', (t) => {
+  t.autoend()
+
+  t.beforeEach((t) => {
+    t.context.originalEnv = { ...process.env }
+    process.env.NEW_RELIC_USE_ESM = 'false'
+    process.env.NEW_RELIC_LAMBDA_HANDLER = 'test/unit/fixtures/cjs/handler.handler'
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'testFn'
+
+    t.context.helper = utils.TestAgent.makeInstrumented()
+  })
+
+  t.afterEach((t) => {
+    const { helper, originalEnv } = t.context
+    process.env = { ...originalEnv }
+    helper.unload()
+  })
+
+  t.test('defaults NEW_RELIC_WORKER_THREADS_ENABLED to true under LMI', (t) => {
+    process.env.AWS_LAMBDA_INITIALIZATION_TYPE = 'lambda-managed-instances'
+    delete process.env.NEW_RELIC_WORKER_THREADS_ENABLED
+
+    proxyquire('../../index', { newrelic: t.context.helper.getAgentApi() })
+
+    t.equal(process.env.NEW_RELIC_WORKER_THREADS_ENABLED, 'true')
+    t.end()
+  })
+
+  t.test('does not override an explicitly-set NEW_RELIC_WORKER_THREADS_ENABLED under LMI', (t) => {
+    process.env.AWS_LAMBDA_INITIALIZATION_TYPE = 'lambda-managed-instances'
+    process.env.NEW_RELIC_WORKER_THREADS_ENABLED = 'false'
+
+    proxyquire('../../index', { newrelic: t.context.helper.getAgentApi() })
+
+    t.equal(process.env.NEW_RELIC_WORKER_THREADS_ENABLED, 'false')
+    t.end()
+  })
+
+  t.test('leaves NEW_RELIC_WORKER_THREADS_ENABLED untouched outside LMI', (t) => {
+    delete process.env.AWS_LAMBDA_INITIALIZATION_TYPE
+    delete process.env.NEW_RELIC_WORKER_THREADS_ENABLED
+
+    proxyquire('../../index', { newrelic: t.context.helper.getAgentApi() })
+
+    t.equal(process.env.NEW_RELIC_WORKER_THREADS_ENABLED, undefined)
+    t.end()
+  })
+})

--- a/nodejs/test/unit/lmiWorkerThreadsEsm.tap.js
+++ b/nodejs/test/unit/lmiWorkerThreadsEsm.tap.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const tap = require('tap')
+const utils = require('@newrelic/test-utilities')
+const td = require('testdouble')
+
+tap.test('Layer Handler - LMI worker_threads default (ESM)', (t) => {
+  t.autoend()
+
+  t.test('defaults NEW_RELIC_WORKER_THREADS_ENABLED to true under LMI', async(t) => {
+    const originalEnv = { ...process.env }
+    process.env.NEW_RELIC_LAMBDA_HANDLER = 'test/unit/fixtures/esm/handler.handler'
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'testFn'
+    process.env.AWS_LAMBDA_INITIALIZATION_TYPE = 'lambda-managed-instances'
+    delete process.env.NEW_RELIC_WORKER_THREADS_ENABLED
+
+    const helper = utils.TestAgent.makeInstrumented()
+    await td.replaceEsm('newrelic', {}, helper.getAgentApi())
+
+    await import('../../esm.mjs')
+
+    t.equal(process.env.NEW_RELIC_WORKER_THREADS_ENABLED, 'true')
+
+    process.env = { ...originalEnv }
+    helper.unload()
+    t.end()
+  })
+})


### PR DESCRIPTION
## Summary
- LMI (Lambda Managed Instances) runs multiple invocations concurrently within a single execution environment, unlike standard Lambda.
- Without `worker_threads` instrumentation enabled, the Node.js agent's context manager can't correctly track concurrent invocations, causing invocations to hang until the function times out.
- Defaults `NEW_RELIC_WORKER_THREADS_ENABLED=true` when `AWS_LAMBDA_INITIALIZATION_TYPE=lambda-managed-instances` is detected, in both `index.js` (CJS) and `esm.mjs` (ESM) wrappers. An explicitly-set value is respected. Standard Lambda deployments are unaffected (env var not set unless already LMI).

## Test plan
- [x] `npm run lint`
- [x] `npm run test:unit` (32/32 passing, including 4 new tests covering: defaults to true under LMI, respects explicit value under LMI, untouched outside LMI, ESM smoke test)
- [x] `npm run test:integration` (87/87 passing across cjs/esm/legacy-esm)
- [x] Verified against a live LMI Node.js Lambda function: every invocation timed out at 30s before this change; consistently succeeded after